### PR TITLE
FIX CODE SCANNING ALERT NO. 244: LIKELY OVERRUNNING WRITE

### DIFF
--- a/utils/mkpkg/mkpkg.c
+++ b/utils/mkpkg/mkpkg.c
@@ -216,7 +216,8 @@ int add_file(FILE *archive, char *srcfn, char *dstfn, int *time, int prebuilt)
         sprintf(hdr->mtime, "%011o", prebuilt ? *time : st.st_mtime);
         memcpy(hdr->chksum, "        ", 8);
         hdr->typeflag = '0';
-        strcpy(hdr->magic, "ustar  ");
+        strncpy(hdr->magic, "ustar  ", sizeof(hdr->magic) - 1);
+        hdr->magic[sizeof(hdr->magic) - 1] = '\0';
         strcpy(hdr->uname, "krlean");
         strcpy(hdr->gname, "krlean");
 


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/244](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/244)._

_To fix the problem, we need to ensure that the string copied into the `magic` field does not exceed its allocated size of 6 bytes. We should use `strncpy` instead of `strcpy` to limit the number of characters copied and ensure that the string is properly null-terminated._
- _Replace the `strcpy` call with `strncpy`, specifying the size of the `magic` field._
- _Ensure that the `magic` field is null-terminated after using `strncpy`._
