### PR TITLE
FIX CODE SCANNING ALERT NO. 2: POTENTIALLY UNSAFE USE OF STRCAT

### DIFF
--- a/utils/mkpkg/mkpkg.c
+++ b/utils/mkpkg/mkpkg.c
@@ -294,8 +294,8 @@ int make_package(struct pkgdb *db, char *inffn)
     description = get_property(manifest, "package", "description", NULL);
 
     strcpy(dstinffn, "/usr/share/pkg/");
-    strcat(dstinffn, pkgname);
-    strcat(dstinffn, ".inf");
+    strncat(dstinffn, pkgname, STRLEN - strlen(dstinffn) - 1);
+    strncat(dstinffn, ".inf", STRLEN - strlen(dstinffn) - 1);
 
     pkg = find_package(db, pkgname);
     if (!pkg)


### PR DESCRIPTION
_This pull request includes a change to the `make_package` function in `utils/mkpkg/mkpkg.c` to improve string concatenation safety by using `strncat` instead of `strcat`._

* _[`utils/mkpkg/mkpkg.c`](diffhunk://#diff-04f020a0db76bf6a418de7f2d303deaeee6596fe017eacedb91ab488a45a53ebL297-R298): Updated `make_package` function to use `strncat` for safer string concatenation, preventing potential buffer overflow issues._