### PR TITLE
FIX CODE SCANNING ALERT NO. 271: USE OF POTENTIALLY DANGEROUS FUNCTION

### DIFF
--- a/sdk/src/as/as.c
+++ b/sdk/src/as/as.c
@@ -199,9 +199,8 @@ static void define_macros_early(void) {
     struct tm lt, *lt_p, gm, *gm_p;
     int64_t posix_time;
 
-    lt_p = localtime(&official_compile_time);
+    lt_p = localtime_r(&official_compile_time, &lt);
     if (lt_p) {
-        lt = *lt_p;
 
         strftime(temp, sizeof temp, "__DATE__=\"%Y-%m-%d\"", &lt);
         pp_pre_define(temp);
@@ -213,9 +212,8 @@ static void define_macros_early(void) {
         pp_pre_define(temp);
     }
 
-    gm_p = gmtime(&official_compile_time);
+    gm_p = gmtime_r(&official_compile_time, &gm);
     if (gm_p) {
-        gm = *gm_p;
 
         strftime(temp, sizeof temp, "__UTC_DATE__=\"%Y-%m-%d\"", &gm);
         pp_pre_define(temp);


### PR DESCRIPTION
_This pull request includes changes to the `sdk/src/as/as.c` file to improve thread safety by replacing non-reentrant functions with their reentrant counterparts._
* _[`sdk/src/as/as.c`](diffhunk://#diff-4895159df92a9ffc48bd3e253c3af83f924a0e15ec305b475a3b0733d27e1959L202-L204): Replaced `localtime` with `localtime_r` to ensure thread safety when converting `official_compile_time` to local time._
* _[`sdk/src/as/as.c`](diffhunk://#diff-4895159df92a9ffc48bd3e253c3af83f924a0e15ec305b475a3b0733d27e1959L216-L218): Replaced `gmtime` with `gmtime_r` to ensure thread safety when converting `official_compile_time` to UTC time._