### PR TITLE
FIX CODE SCANNING ALERT NO. 273: USE OF POTENTIALLY DANGEROUS FUNCTION

### DIFF
--- a/sdk/src/cc/preproc.c
+++ b/sdk/src/cc/preproc.c
@@ -2340,14 +2340,14 @@ int macro_subst_tok(TokenString *tok_str, Sym **nested_list, Sym *s, struct macr
         goto add_cstr;
     } else if (tok == TOK___DATE__ || tok == TOK___TIME__) {
         time_t ti;
-        struct tm *tm;
+        struct tm tm;
 
         time(&ti);
-        tm = localtime(&ti);
+        localtime_r(&ti, &tm);
         if (tok == TOK___DATE__) {
-            snprintf(buf, sizeof(buf), "%s %2d %d", ab_month_name[tm->tm_mon], tm->tm_mday, tm->tm_year + 1900);
+            snprintf(buf, sizeof(buf), "%s %2d %d", ab_month_name[tm.tm_mon], tm.tm_mday, tm.tm_year + 1900);
         } else {
-            snprintf(buf, sizeof(buf), "%02d:%02d:%02d", tm->tm_hour, tm->tm_min, tm->tm_sec);
+            snprintf(buf, sizeof(buf), "%02d:%02d:%02d", tm.tm_hour, tm.tm_min, tm.tm_sec);
         }
         cstrval = buf;
         add_cstr:


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/273](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/273)._

_This pull request includes an important change to the `sdk/src/cc/preproc.c` file to improve thread safety by replacing the use of `localtime` with `localtime_r`._
* _[`sdk/src/cc/preproc.c`](diffhunk://#diff-0dd037ad50e83978d62efc0a107201da2e986f624461c6ed4c252ebc4444c02aL2343-R2350): Replaced the use of `localtime` with `localtime_r` to ensure thread safety when handling time data. Updated the `struct tm` variable usage accordingly._
