### PR TITLE
FIX CODE SCANNING ALERT NO. 558: POSSIBLY WRONG BUFFER SIZE IN STRING COPY

### DIFF
--- a/sdk/src/cc/symbol.c
+++ b/sdk/src/cc/symbol.c
@@ -49,8 +49,9 @@ Section *new_section(CCState *s1, const char *name, int sh_type, int sh_flags)
 {
     Section *sec;
 
-    sec = cc_mallocz(sizeof(Section) + strlen(name) + 1);
-    strncpy(sec->name, name, strlen(name) + 1);
+    size_t name_len = strlen(name) + 1;
+    sec = cc_mallocz(sizeof(Section) + name_len);
+    strncpy(sec->name, name, name_len);
     sec->sh_type = sh_type;
     sec->sh_flags = sh_flags;
     switch (sh_type)


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/558](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/558)._

_To fix the problem, we need to ensure that the third argument of the `strncpy` function is the size of the destination buffer. In this case, the destination buffer is `sec->name`, and its size can be derived from the allocation size. We should use `strlen(name) + 1` as the size of the destination buffer since it was allocated with this size._
