### PR TITLE
FIX CODE SCANNING ALERT NO. 252: UNBOUNDED WRITE

### DIFF
--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -1620,7 +1620,8 @@ int pe_load_def_file(CCState *s1, int fd)
         case 0:
             if (strncasecmp(p, "LIBRARY", 7) != 0)
                 goto quit;
-            strcpy(dllname, trimfront(p + 7));
+            strncpy(dllname, trimfront(p + 7), sizeof(dllname) - 1);
+            dllname[sizeof(dllname) - 1] = '\0';
             ++state;
             continue;
 


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/252](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/252)._

_To fix the problem, we should replace the `strcpy` function with `strncpy`, which allows us to specify the maximum number of characters to copy, thus preventing buffer overflow. We need to ensure that the destination buffer is null-terminated after copying the string. The changes should be made in the `pe_load_def_file` function in the file `sdk/src/cc/pe.c`._
