### PR TITLE
FIX CODE SCANNING ALERT NO. 249: UNBOUNDED WRITE

### DIFF
--- a/sdk/src/as/aslib.c
+++ b/sdk/src/as/aslib.c
@@ -161,7 +161,8 @@ char *as_strdup(const char *s)
         fprintf(logfp, "%s %d strdup(%ld) returns %p\n",
                 file, line, (long)size, p);
 #endif
-    strcpy(p, s);
+    strncpy(p, s, size - 1);
+    p[size - 1] = '\0';
     return p;
 }
 


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/249](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/249)._

_To fix the problem, we should replace the `strcpy` function with `strncpy`, which allows us to specify the maximum number of characters to copy, thus preventing buffer overflow. We need to ensure that the destination buffer is large enough to hold the source string plus the null terminator._ 

_In the file `sdk/src/as/aslib.c`, we will replace the `strcpy` call with `strncpy` and ensure that the buffer size is correctly handled._
