### PR TITLE
FIX CODE SCANNING ALERT NO. 250: UNBOUNDED WRITE

### DIFF
--- a/sdk/src/as/preproc.c
+++ b/sdk/src/as/preproc.c
@@ -1772,7 +1772,8 @@ static FILE *inc_fopen(const char *file, StrList **dhead, StrList ***dtail,
             {
                 sl = as_malloc(len + 1 + sizeof sl->next);
                 sl->next = NULL;
-                strcpy(sl->str, file);
+                strncpy(sl->str, file, len);
+                sl->str[len] = '\0'; // Ensure null termination
                 **dtail = sl;
                 *dtail = &sl->next;
             }


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/250](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/250)._

_To fix the problem, we need to replace the `strcpy` function with a safer alternative that performs bounds checking. The `strncpy` function is a suitable replacement as it allows specifying the maximum number of characters to copy, thus preventing buffer overflow._
- _Replace the `strcpy` call on line 1775 in `sdk/src/as/preproc.c` with `strncpy`._
- _Ensure that the length of the destination buffer is correctly calculated to accommodate the length of the `file` variable and the null terminator._
