### PR TITLE
FIX CODE SCANNING ALERT NO. 509: UNCONTROLLED DATA USED IN PATH EXPRESSION

### DIFF
--- a/src/utils/ar/ar.c
+++ b/src/utils/ar/ar.c
@@ -515,6 +515,16 @@ void usage()
     fprintf(stderr, "  -m            Add individual entries in input archives.\n");
 }
 
+int is_valid_filename(const char *filename)
+{
+    // Check for invalid sequences in the user input
+    if (strstr(filename, "..") || strchr(filename, '/') || strchr(filename, '\\'))
+    {
+        return 0;
+    }
+    return 1;
+}
+
 int main(int argc, char *argv[])
 {
     int c, fd;
@@ -547,6 +557,13 @@ int main(int argc, char *argv[])
         return 1;
     }
     archive_filename = argv[optind++];
+
+    // Validate the archive filename
+    if (!is_valid_filename(archive_filename))
+    {
+        fprintf(stderr, "Invalid archive filename.\n");
+        return 1;
+    }
 
     // Read all the input object files
     init_archive(&ar);


### PR DESCRIPTION
_Fixes [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/509](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/509)._

_To fix the problem, we need to validate the `archive_filename` to ensure it does not contain any potentially dangerous sequences such as ".." or path separators. This can be done by checking for the presence of these sequences and rejecting the input if any are found. Additionally, we can ensure that the resolved path is within a specific directory to further mitigate the risk._
1. _Add a function to validate the `archive_filename` by checking for invalid sequences._
2. _Use this function to validate the `archive_filename` before using it in the `open` function._