### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 507: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/src/utils/ar/ar.c
+++ b/src/utils/ar/ar.c
@@ -596,7 +596,7 @@ int main(int argc, char *argv[])
     }
 
     // Open output archive
-    fd = open(archive_filename, O_CREAT | O_TRUNC | O_WRONLY | O_BINARY, 0666);
+    fd = open(archive_filename, O_CREAT | O_TRUNC | O_WRONLY | O_BINARY, S_IWUSR | S_IRUSR);
     if (fd < 0)
     {
         perror(archive_filename);


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/507](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/507)._

_To fix the problem, we need to change the file creation mode from `0666` to a more restrictive mode that allows only the current user to read and write to the file. The appropriate mode for this is `S_IWUSR | S_IRUSR`, which corresponds to `0600` in octal notation. This change ensures that the file is not world-writable and only the owner has read and write permissions._

_We need to modify the `open` function call on line 599 to use the new mode. No additional methods or imports are required, as the necessary constants are already included from the `<sys/stat.h>` header._
