### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 17: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/utils/mkpkg/mkpkg.c
+++ b/utils/mkpkg/mkpkg.c
@@ -120,10 +120,18 @@ static int write_pkgdb(char *dbfile, struct pkgdb *db)
 {
     FILE *f;
     struct pkg *pkg;
+    int fd;
 
-    f = fopen(dbfile, "w");
+    fd = open(dbfile, O_WRONLY | O_CREAT | O_TRUNC, S_IWUSR | S_IRUSR);
+    if (fd < 0)
+    {
+        perror(dbfile);
+        return 1;
+    }
+    f = fdopen(fd, "w");
     if (!f)
     {
+        close(fd);
         perror(dbfile);
         return 1;
     }


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/17](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/17)._

_To fix the problem, we need to ensure that the file is created with restrictive permissions, allowing only the current user to read and write to the file. This can be achieved by using the `open` function with the appropriate flags and permissions, and then converting the file descriptor to a `FILE *` stream using `fdopen`._
- _Replace the `fopen` call with `open` to create the file with specific permissions._
- _Use `fdopen` to convert the file descriptor to a `FILE *` stream._
- _Ensure that the file is created with `S_IWUSR | S_IRUSR` permissions, which allow only the current user to read and write to the file._
