### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 16: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/utils/mkpkg/mkpkg.c
+++ b/utils/mkpkg/mkpkg.c
@@ -322,7 +322,17 @@ int make_package(struct pkgdb *db, char *inffn)
     joinpath(dstdir, pkgname, dstpkgfn);
     strcat(dstpkgfn, ".pkg");
 
-    archive = fopen(dstpkgfn, "w");
+    int fd = open(dstpkgfn, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
+    if (fd < 0) {
+        // handle error
+        return 1;
+    }
+    archive = fdopen(fd, "w");
+    if (archive == NULL) {
+        close(fd);
+        // handle error
+        return 1;
+    }
     if (add_file(archive, inffn, pkg->inffile, &pkg->time, 0) != 0)
     {
         fclose(archive);


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/16](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/16)._

_To fix the problem, we need to ensure that the file is created with restrictive permissions, specifically allowing only the current user to read and write to the file. This can be achieved by using the `open` function with the `O_WRONLY | O_CREAT` flags and specifying the permissions `S_IWUSR | S_IRUSR`. After obtaining the file descriptor, we can use `fdopen` to get a `FILE *` stream pointer for writing to the file._
