### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 263: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -1,4 +1,5 @@
 #include "cc.h"
+#include <sys/stat.h>
 
 #define PE_MERGE_DATA
 
@@ -595,7 +596,7 @@ static int pe_write(struct pe_info *pe)
     }
     ((PIMAGE_DOS_HEADER)stub)->e_lfanew = stub_size;
 
-    fd = open(pe->filename, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0777);
+    fd = open(pe->filename, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, S_IWUSR | S_IRUSR);
     if (fd < 0)
     {
         error_noabort("could not write '%s': %s", pe->filename, strerror(errno));


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/263](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/263)._

_To fix the problem, we need to change the file creation mode from `0777` to a more restrictive mode that allows only the current user to read and write to the file. The appropriate mode for this is `S_IWUSR | S_IRUSR`, which corresponds to `0600` in octal notation. This change should be made on line 598 where the `open` function is called._
