### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 403: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/sdk/src/cc/cc.c
+++ b/sdk/src/cc/cc.c
@@ -528,9 +528,12 @@ int main(int argc, char **argv)
         }
         else
         {
-            s->outfile = fopen(outfile, "w");
-            if (!s->outfile)
+            int fd = open(outfile, O_WRONLY | O_CREAT | O_TRUNC, S_IWUSR | S_IRUSR);
+            if (fd < 0)
                 error("could not open '%s", outfile);
+            s->outfile = fdopen(fd, "w");
+            if (!s->outfile)
+                error("could not fdopen '%s", outfile);
         }
     }
     else

--- a/sdk/src/cc/cc.h
+++ b/sdk/src/cc/cc.h
@@ -5,6 +5,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <math.h>
 #include <setjmp.h>
 #include <stdarg.h>
@@ -20,7 +21,7 @@
 #include "elf.h"
 
 #ifndef offsetof
-#define offsetof(type, field) ((size_t)&((type *)0)->field)
+#define offsetof(type, field) ((size_t) & ((type *)0)->field)
 #endif
 
 #ifndef countof


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/403](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/403)._

_To fix the problem, we need to ensure that the file is created with restrictive permissions, allowing only the current user to read and write to the file. This can be achieved by using the `open` function with the appropriate flags and permissions, and then converting the file descriptor to a `FILE *` stream using `fdopen`._
- _Replace the `fopen` call with `open` to create the file with `S_IWUSR | S_IRUSR` permissions._
- _Use `fdopen` to convert the file descriptor to a `FILE *` stream._
- _Ensure that error handling is in place for both `open` and `fdopen`._
