### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 262: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -927,17 +927,26 @@ static void pe_build_exports(struct pe_info *pe)
     if (pe->def != NULL)
     {
         // Write exports to .def file
-        op = fopen(pe->def, "w");
-        if (op == NULL)
+        int fd = open(pe->def, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
+        if (fd < 0)
         {
             error_noabort("could not create '%s': %s", pe->def, strerror(errno));
         }
         else
         {
-            fprintf(op, "LIBRARY %s\n\nEXPORTS\n", dllname);
-            if (verbose)
+            op = fdopen(fd, "w");
+            if (op == NULL)
             {
-                printf("<- %s (%d symbols)\n", buf, sym_count);
+                close(fd);
+                error_noabort("could not create '%s': %s", pe->def, strerror(errno));
+            }
+            else
+            {
+                fprintf(op, "LIBRARY %s\n\nEXPORTS\n", dllname);
+                if (verbose)
+                {
+                    printf("<- %s (%d symbols)\n", buf, sym_count);
+                }
             }
         }
     }


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/262](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/262)._

_To fix the problem, we need to ensure that the file is created with restrictive permissions, specifically allowing only the current user to read and write to the file. This can be achieved by using the `open` function with the `O_WRONLY | O_CREAT` flags and specifying the desired permissions (`S_IWUSR | S_IRUSR`). After obtaining the file descriptor, we can use `fdopen` to get a `FILE *` stream pointer for writing to the file._
- _Replace the `fopen` call with `open` to create the file with restrictive permissions._
- _Use `fdopen` to convert the file descriptor to a `FILE *` stream pointer._
- _Ensure that the file is closed properly after writing._
