### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 261: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -1524,7 +1524,17 @@ static void pe_print_sections(CCState *s1, const char *fname)
     Section *s;
     FILE *f;
     int i;
-    f = fopen(fname, "wt");
+    int fd = open(fname, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+    if (fd < 0) {
+        // handle error
+        return;
+    }
+    f = fdopen(fd, "wt");
+    if (f == NULL) {
+        close(fd);
+        // handle error
+        return;
+    }
     for (i = 1; i < s1->nb_sections; ++i)
     {
         s = s1->sections[i];


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/261](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/261)._

_To fix the problem, we need to ensure that the file is created with restrictive permissions, allowing only the current user to read and write to the file. This can be achieved by using the `open` function with the appropriate flags and permissions instead of `fopen`. The `open` function allows us to specify the permissions explicitly._

_We will replace the `fopen` call with an `open` call, followed by `fdopen` to get a `FILE *` stream pointer if needed. This ensures that the file is created with the desired permissions._
