### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 402: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/sdk/src/as/as.c
+++ b/sdk/src/as/as.c
@@ -27,6 +27,8 @@
 #include "labels.h"
 #include "out/outform.h"
 #include "listing.h"
+#include <sys/stat.h>
+#include <fcntl.h>
 
 /*
  * This is the maximum number of optimization passes to do.  If we ever

--- a/sdk/src/as/as.c
+++ b/sdk/src/as/as.c
@@ -268,9 +268,17 @@ static void emit_dependencies(StrList *list)
 
     if (depend_file && strcmp(depend_file, "-"))
     {
-        deps = fopen(depend_file, "w");
+        int fd = open(depend_file, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
+        if (fd < 0)
+        {
+            as_error(ERR_NONFATAL | ERR_NOFILE | ERR_USAGE,
+                     "unable to write dependency file `%s'", depend_file);
+            return;
+        }
+        deps = fdopen(fd, "w");
         if (!deps)
         {
+            close(fd);
             as_error(ERR_NONFATAL | ERR_NOFILE | ERR_USAGE,
                      "unable to write dependency file `%s'", depend_file);
             return;


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/402](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/402)._

_To fix the problem, we need to ensure that the file is created with restrictive permissions, allowing only the current user to read and write to the file. This can be achieved by using the `open` function with the `O_WRONLY | O_CREAT` flags and specifying the permissions `S_IWUSR | S_IRUSR`. After opening the file, we can use `fdopen` to get a `FILE *` stream pointer if needed._
1. _Replace the `fopen` call with `open` to create the file with restrictive permissions._
2. _Use `fdopen` to convert the file descriptor to a `FILE *` stream pointer._
3. _Ensure that the file is properly closed after use._
