### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 400: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/sdk/src/as/as.c
+++ b/sdk/src/as/as.c
@@ -1232,13 +1232,25 @@ static void parse_cmdline(int argc, char **argv)
 
     if (*errname)
     {
-        error_file = fopen(errname, "w");
-        if (!error_file)
+        int fd = open(errname, O_WRONLY | O_CREAT | O_TRUNC, S_IWUSR | S_IRUSR);
+        if (fd < 0)
         {
             error_file = stderr; /* Revert to default! */
             as_error(ERR_FATAL | ERR_NOFILE | ERR_USAGE,
                      "cannot open file `%s' for error messages",
                      errname);
+        }
+        else
+        {
+            error_file = fdopen(fd, "w");
+            if (!error_file)
+            {
+                close(fd);
+                error_file = stderr; /* Revert to default! */
+                as_error(ERR_FATAL | ERR_NOFILE | ERR_USAGE,
+                         "cannot open file `%s' for error messages",
+                         errname);
+            }
         }
     }
 }


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/400](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/400)._

_To fix the problem, we need to ensure that the file is created with restrictive permissions, allowing only the current user to read and write to it. This can be achieved by using the `open` function with the appropriate flags and permissions, and then converting the file descriptor to a `FILE *` stream using `fdopen`._
- _Replace the `fopen` call with `open` to create the file with `S_IWUSR | S_IRUSR` permissions._
- _Use `fdopen` to convert the file descriptor to a `FILE *` stream._
- _Ensure that the error handling remains consistent with the original code._
