### PR TITLE
Potential fix for code scanning alert no. 401: File created without restricting permissions

### DIFF
--- a/sdk/src/as/as.c
+++ b/sdk/src/as/as.c
@@ -398,11 +398,19 @@ int main(int argc, char **argv)
 
         if (*outname)
         {
-            ofile = fopen(outname, "w");
-            if (!ofile)
+            int fd = open(outname, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
+            if (fd < 0)
                 as_error(ERR_FATAL | ERR_NOFILE,
                          "unable to open output file `%s'",
                          outname);
+            ofile = fdopen(fd, "w");
+            if (!ofile)
+            {
+                close(fd);
+                as_error(ERR_FATAL | ERR_NOFILE,
+                         "unable to open output file `%s'",
+                         outname);
+            }
         }
         else
             ofile = NULL;


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/401](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/401)._

_To fix the problem, we need to ensure that the file created by `fopen` has restrictive permissions, specifically allowing only the current user to read and write to the file. The best way to achieve this is to use the `open` function with the `O_WRONLY | O_CREAT` flags and the `S_IWUSR | S_IRUSR` mode, and then convert the file descriptor to a `FILE *` stream using `fdopen`. This approach ensures that the file is created with the correct permissions._
