### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 398: FILE CREATED WITHOUT RESTRICTING PERMISSIONS

### DIFF
--- a/sdk/src/as/listing.c
+++ b/sdk/src/as/listing.c
@@ -10,6 +10,8 @@
 #include <string.h>
 #include <ctype.h>
 #include <inttypes.h>
+#include <fcntl.h>
+#include <sys/stat.h>
 
 #include "as.h"
 #include "aslib.h"
@@ -97,9 +99,17 @@ static void list_emit(void)
 
 static void list_init(char *fname, efunc error)
 {
-    listfp = fopen(fname, "w");
+    int fd = open(fname, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
+    if (fd < 0)
+    {
+        error(ERR_NONFATAL, "unable to open listing file `%s'",
+              fname);
+        return;
+    }
+    listfp = fdopen(fd, "w");
     if (!listfp)
     {
+        close(fd);
         error(ERR_NONFATAL, "unable to open listing file `%s'",
               fname);
         return;


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/398](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/398)._

_To fix the problem, we need to ensure that the file is created with restrictive permissions, specifically allowing only the current user to read and write to the file. This can be achieved by using the `open` function with the `O_WRONLY | O_CREAT` flags and specifying the permissions `S_IWUSR | S_IRUSR`. After obtaining the file descriptor, we can use `fdopen` to get a `FILE *` stream pointer for further operations._
