### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 594-2: UNCONTROLLED DATA USED IN PATH EXPRESSION 

### DIFF
--- a/sdk/src/as/as.c
+++ b/sdk/src/as/as.c
@@ -272,6 +272,12 @@ static void emit_dependencies(StrList *list)
 
     if (depend_file && strcmp(depend_file, "-"))
     {
+        if (has_path_traversal(depend_file))
+        {
+            as_error(ERR_NONFATAL | ERR_NOFILE | ERR_USAGE,
+                     "invalid dependency file path `%s'", depend_file);
+            return;
+        }
         int fd = open(depend_file, O_WRONLY | O_CREAT, S_IWUSR | S_IRUSR);
         if (fd < 0)
         {


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/594](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/594)._

_To fix the problem, we need to validate the `depend_file` variable before it is used in the `open` function call. We can use the existing `has_path_traversal` function to check for path traversal patterns and ensure that the path is safe. If the path is found to be unsafe, we should handle the error appropriately._
