### PR TITLE
POTENTIAL FIX FOR CODE SCANNING ALERT NO. 587: UNCONTROLLED DATA USED IN PATH EXPRESSION

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/devcontainers/cpp:ubuntu
+USER root
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install build-essential cmake cppcheck valgrind clang lldb llvm gdb \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+ENV VCPKG_ROOT=/usr/local/vcpkg \
+    VCPKG_DOWNLOADS=/usr/local/vcpkg-downloads
+ENV PATH="${PATH}:${VCPKG_ROOT}"
+
+ARG USERNAME=vscode
+COPY base-scripts/install-vcpkg.sh /tmp/
+RUN chmod +x /tmp/install-vcpkg.sh \
+    && ./tmp/install-vcpkg.sh ${USERNAME} \
+    && rm -f /tmp/install-vcpkg.sh
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends gcc-multilib libc6-dev-i386 genisoimage sudo

--- a/.devcontainer/base-scripts/install-vcpkg.sh
+++ b/.devcontainer/base-scripts/install-vcpkg.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+set -e
+
+USERNAME=${1:-"vscode"}
+
+. /etc/os-release
+
+# Add to bashrc/zshrc files for all users.
+updaterc()  {
+    echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc..."
+    if [[ "$(cat /etc/bash.bashrc)" != *"$1"* ]]; then
+        echo -e "$1" >> /etc/bash.bashrc
+    fi
+    if [ -f "/etc/zsh/zshrc" ] && [[ "$(cat /etc/zsh/zshrc)" != *"$1"* ]]; then
+        echo -e "$1" >> /etc/zsh/zshrc
+    fi
+}
+
+# Run apt-get if needed.
+apt_get_update_if_needed() {
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Check if packages are installed and installs them if not.
+check_packages() {
+    if ! dpkg -s "$@" > /dev/null 2>&1; then
+        apt_get_update_if_needed
+        apt-get -y install --no-install-recommends "$@"
+    fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+export VCPKG_FORCE_SYSTEM_BINARIES=1
+
+# Install additional packages needed by vcpkg: https://github.com/microsoft/vcpkg/blob/master/README.md#installing-linux-developer-tools
+check_packages build-essential tar curl zip unzip pkg-config bash-completion ninja-build
+
+# Setup group and add user
+umask 0002
+if ! cat /etc/group | grep -e "^vcpkg:" > /dev/null 2>&1; then
+    groupadd -r "vcpkg"
+fi
+usermod -a -G "vcpkg" "${USERNAME}"
+
+# Start Installation
+# Clone repository with ports and installer
+mkdir -p "${VCPKG_ROOT}"
+mkdir -p "${VCPKG_DOWNLOADS}"
+git clone --depth=1 \
+    -c core.eol=lf \
+    -c core.autocrlf=false \
+    -c fsck.zeroPaddedFilemode=ignore \
+    -c fetch.fsck.zeroPaddedFilemode=ignore \
+    -c receive.fsck.zeroPaddedFilemode=ignore \
+    https://github.com/microsoft/vcpkg "${VCPKG_ROOT}"
+
+## Run installer to get latest stable vcpkg binary
+## https://github.com/microsoft/vcpkg/blob/7e7dad5fe20cdc085731343e0e197a7ae655555b/scripts/bootstrap.sh#L126-L144
+"${VCPKG_ROOT}"/bootstrap-vcpkg.sh
+
+# Add vcpkg to PATH
+updaterc "$(cat << EOF
+export VCPKG_ROOT="${VCPKG_ROOT}"
+if [[ "\${PATH}" != *"\${VCPKG_ROOT}"* ]]; then export PATH="\${PATH}:\${VCPKG_ROOT}"; fi
+EOF
+)"
+
+# Give read/write permissions to the user group.
+chown -R ":vcpkg" "${VCPKG_ROOT}" "${VCPKG_DOWNLOADS}"
+chmod g+r+w+s "${VCPKG_ROOT}" "${VCPKG_DOWNLOADS}"
+chmod -R g+r+w "${VCPKG_ROOT}" "${VCPKG_DOWNLOADS}"
+
+# Enable tab completion for bash and zsh
+VCPKG_FORCE_SYSTEM_BINARIES=1 su "${USERNAME}" -c "${VCPKG_ROOT}/vcpkg integrate bash"
+VCPKG_FORCE_SYSTEM_BINARIES=1 su "${USERNAME}" -c "${VCPKG_ROOT}/vcpkg integrate zsh"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+	"build": {
+		"dockerfile": "./Dockerfile",
+		"context": "."
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/git:1": {
+            "version": "latest",
+            "ppa": "false"
+        }
+    },
+	"capAdd": ["SYS_PTRACE"],
+	"securityOpt": ["seccomp=unconfined"],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools",
+				"ms-vscode.cmake-tools",
+				"twxs.cmake",
+				"github.vscode-github-actions",
+				"GitHub.copilot",
+				"GitHub.copilot-chat",
+				"VisualStudioExptTeam.vscodeintellicode"
+			]
+		}
+	},
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "make krlean cdrom floppy vmdk",
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -1593,10 +1593,12 @@ static void pe_print_sections(CCState *s1, const char *fname)
         }
     }
 
-    ret = pe_print_section(f, s1->dynsymtab_section);
-    if (ret < 0) {
-        error_noabort("error writing dynsym section to map file");
-        goto error;
+    if (s1->dynsymtab_section) {
+        ret = pe_print_section(f, s1->dynsymtab_section);
+        if (ret < 0) {
+            error_noabort("error writing dynsym section to map file");
+            goto error;
+        }
     }
 
 error:

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -485,8 +485,10 @@ static DWORD umax(DWORD a, DWORD b)
 static int pe_fpad(FILE *fp, DWORD new_pos, char fill)
 {
     DWORD pos = ftell(fp);
-    while (pos < new_pos) {
-        if (fputc(fill, fp) == EOF) {
+    while (pos < new_pos)
+    {
+        if (fputc(fill, fp) == EOF)
+        {
             return -1;
         }
         pos++;
@@ -511,9 +513,21 @@ static DWORD pe_virtual_align(DWORD n)
 
 static void pe_align_section(Section *s, int a)
 {
-    int padding = ((a - (s->data_offset & (a - 1))) & (a - 1));
-    if (padding)
-        section_ptr_add(s, padding);
+    int padding;
+    char *pad;
+
+    if (!s || a <= 0)
+        return;
+
+    padding = ((a - (s->data_offset & (a - 1))) & (a - 1));
+    if (padding > 0)
+    {
+        pad = section_ptr_add(s, padding);
+        if (pad)
+        {
+            memset(pad, 0, padding);
+        }
+    }
 }
 
 static void pe_set_datadir(int dir, DWORD addr, DWORD size)
@@ -621,7 +635,8 @@ static int pe_write(struct pe_info *pe)
                           pe->sec_count * sizeof(IMAGE_SECTION_HEADER));
 
     file_offset = pe->sizeofheaders;
-    if (pe_fpad(op, file_offset, 0) < 0) {
+    if (pe_fpad(op, file_offset, 0) < 0)
+    {
         error_noabort("error writing section padding");
         return 1;
     }
@@ -702,7 +717,8 @@ static int pe_write(struct pe_info *pe)
                 if (sect->sh_type != SHT_NOBITS)
                 {
                     file_offset = align(file_offset, sect->sh_addralign);
-                    if (pe_fpad(op, file_offset, si->cls == sec_text ? 0x90 : 0x00) < 0) {
+                    if (pe_fpad(op, file_offset, si->cls == sec_text ? 0x90 : 0x00) < 0)
+                    {
                         error_noabort("error writing section padding");
                         return 1;
                     }
@@ -712,7 +728,8 @@ static int pe_write(struct pe_info *pe)
             }
             file_offset = pe_file_align(pe, file_offset);
             psh->SizeOfRawData = file_offset - r;
-            if (pe_fpad(op, file_offset, 0) < 0) {
+            if (pe_fpad(op, file_offset, 0) < 0)
+            {
                 error_noabort("error writing section padding");
                 return 1;
             }
@@ -1412,24 +1429,32 @@ static void pe_eliminate_unused_sections(struct pe_info *pe)
     }
 }
 
-static int pe_print_section(FILE *f, Section *s) {
-    BYTE *data_ptr, *e, b; 
+static int pe_print_section(FILE *f, Section *s)
+{
+    BYTE *data_ptr, *e, b;
     int i, n, l, m;
-    
-    if (!f || !s) return -1;
+
+    if (!f || !s)
+        return -1;
 
     data_ptr = s->data;
     e = s->data + s->data_offset;
     l = (e > data_ptr) ? (int)(e - data_ptr) : 0;
 
-    if (fprintf(f, "section  \"%s\"", s->name) < 0) return -1;
+    if (fprintf(f, "section  \"%s\"", s->name) < 0)
+        return -1;
     if (s->link)
-        if (fprintf(f, "\nlink     \"%s\"", s->link->name) < 0) return -1;
+        if (fprintf(f, "\nlink     \"%s\"", s->link->name) < 0)
+            return -1;
     if (s->reloc)
-        if (fprintf(f, "\nreloc    \"%s\"", s->reloc->name) < 0) return -1;
-    if (fprintf(f, "\nv_addr   %08X", s->sh_addr) < 0) return -1;
-    if (fprintf(f, "\ncontents %08X", l) < 0) return -1;
-    if (fprintf(f, "\n\n") < 0) return -1;
+        if (fprintf(f, "\nreloc    \"%s\"", s->reloc->name) < 0)
+            return -1;
+    if (fprintf(f, "\nv_addr   %08X", s->sh_addr) < 0)
+        return -1;
+    if (fprintf(f, "\ncontents %08X", l) < 0)
+        return -1;
+    if (fprintf(f, "\n\n") < 0)
+        return -1;
 
     if (s->sh_type == SHT_NOBITS)
         return 0;
@@ -1449,9 +1474,11 @@ static int pe_print_section(FILE *f, Section *s) {
         m = 16;
     }
 
-    if (fprintf(f, "%-8s", "offset") < 0) return -1;
+    if (fprintf(f, "%-8s", "offset") < 0)
+        return -1;
     for (i = 0; i < m; ++i)
-        if (fprintf(f, " %02x", i) < 0) return -1;
+        if (fprintf(f, " %02x", i) < 0)
+            return -1;
     n = 56;
 
     if (s->sh_type == SHT_SYMTAB || s->sh_type == SHT_REL)
@@ -1472,27 +1499,35 @@ static int pe_print_section(FILE *f, Section *s) {
         }
 
         for (i = 0; field_names[i]; ++i) // Use renamed variable
-            if (fprintf(f, "%s", field_names[i]) < 0) return -1;
-        if (fprintf(f, "  symbol") < 0) return -1;
+            if (fprintf(f, "%s", field_names[i]) < 0)
+                return -1;
+        if (fprintf(f, "  symbol") < 0)
+            return -1;
     }
 
-    if (fprintf(f, "\n") < 0) return -1;
+    if (fprintf(f, "\n") < 0)
+        return -1;
     for (i = 0; i < n; ++i)
-        if (fprintf(f, "-") < 0) return -1;
-    if (fprintf(f, "\n") < 0) return -1;
+        if (fprintf(f, "-") < 0)
+            return -1;
+    if (fprintf(f, "\n") < 0)
+        return -1;
 
     for (i = 0; i < l;)
     {
-        if (fprintf(f, "%08X", i) < 0) return -1;
+        if (fprintf(f, "%08X", i) < 0)
+            return -1;
         for (n = 0; n < m; ++n)
         {
             if (n + i < l)
             {
-                if (fprintf(f, " %02X", data_ptr[i + n]) < 0) return -1; // Use renamed variable
+                if (fprintf(f, " %02X", data_ptr[i + n]) < 0)
+                    return -1; // Use renamed variable
             }
             else
             {
-                if (fprintf(f, "   ") < 0) return -1;
+                if (fprintf(f, "   ") < 0)
+                    return -1;
             }
         }
 
@@ -1501,12 +1536,13 @@ static int pe_print_section(FILE *f, Section *s) {
             Elf32_Sym *sym = (Elf32_Sym *)(data_ptr + i); // Use renamed variable
             const char *name = s->link->data + sym->st_name;
             if (fprintf(f, "  %04X  %08X  %04X   %02X    %02X    %02X   %04X  \"%s\"",
-                    sym->st_name,
-                    sym->st_value,
-                    sym->st_size,
-                    ELF32_ST_BIND(sym->st_info),
-                    ELF32_ST_TYPE(sym->st_info),
-                    sym->st_other, sym->st_shndx, name) < 0) return -1;
+                        sym->st_name,
+                        sym->st_value,
+                        sym->st_size,
+                        ELF32_ST_BIND(sym->st_info),
+                        ELF32_ST_TYPE(sym->st_info),
+                        sym->st_other, sym->st_shndx, name) < 0)
+                return -1;
         }
         else if (s->sh_type == SHT_REL)
         {
@@ -1514,13 +1550,15 @@ static int pe_print_section(FILE *f, Section *s) {
             Elf32_Sym *sym = (Elf32_Sym *)s->link->data + ELF32_R_SYM(rel->r_info);
             const char *name = s->link->link->data + sym->st_name;
             if (fprintf(f, "  %04X   %02X   %04X  \"%s\"",
-                    rel->r_offset,
-                    ELF32_R_TYPE(rel->r_info),
-                    ELF32_R_SYM(rel->r_info), name) < 0) return -1;
+                        rel->r_offset,
+                        ELF32_R_TYPE(rel->r_info),
+                        ELF32_R_SYM(rel->r_info), name) < 0)
+                return -1;
         }
         else
         {
-            if (fprintf(f, "   ") < 0) return -1;
+            if (fprintf(f, "   ") < 0)
+                return -1;
             for (n = 0; n < m; ++n)
             {
                 if (n + i < l)
@@ -1528,14 +1566,17 @@ static int pe_print_section(FILE *f, Section *s) {
                     b = data_ptr[i + n]; // Use renamed variable
                     if (b < 32 || b >= 127)
                         b = '.';
-                    if (fprintf(f, "%c", b) < 0) return -1;
+                    if (fprintf(f, "%c", b) < 0)
+                        return -1;
                 }
             }
         }
         i += m;
-        if (fprintf(f, "\n") < 0) return -1;
+        if (fprintf(f, "\n") < 0)
+            return -1;
     }
-    if (fprintf(f, "\n\n") < 0) return -1;
+    if (fprintf(f, "\n\n") < 0)
+        return -1;
     return 0;
 }
 
@@ -1584,29 +1625,35 @@ static void pe_print_sections(CCState *s1, const char *fname)
     int i, ret;
     char errbuf[256];
 
-    if (!fname) {
+    if (!fname)
+    {
         error_noabort("map file name is NULL");
         return;
     }
 
     f = open_map_file(fname, errbuf, sizeof(errbuf));
-    if (!f) {
+    if (!f)
+    {
         error_noabort("%s", errbuf);
         return;
     }
 
-    for (i = 1; i < s1->nb_sections; ++i) {
+    for (i = 1; i < s1->nb_sections; ++i)
+    {
         sect = s1->sections[i];
         ret = pe_print_section(f, sect);
-        if (ret < 0) {
+        if (ret < 0)
+        {
             error_noabort("error writing section %d to map file", i);
             goto error;
         }
     }
 
-    if (s1->dynsymtab_section) {
+    if (s1->dynsymtab_section)
+    {
         ret = pe_print_section(f, s1->dynsymtab_section);
-        if (ret < 0) {
+        if (ret < 0)
+        {
             error_noabort("error writing dynsym section to map file");
             goto error;
         }

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -1751,7 +1751,6 @@ quit:
 static void pe_add_runtime_ex(CCState *s1, struct pe_info *pe)
 {
     const char *start_symbol;
-    unsigned long addr = 0;
     int pe_type = 0;
     int start_sym_index;
 

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -1400,11 +1400,11 @@ static void pe_eliminate_unused_sections(struct pe_info *pe)
 
 static void pe_print_section(FILE *f, Section *s)
 {
-    BYTE *p, *e, b;
+    BYTE *data_ptr, *e, b;  // Changed p to data_ptr
     int i, n, l, m;
-    p = s->data;
+    data_ptr = s->data;     // Use renamed variable
     e = s->data + s->data_offset;
-    l = e - p;
+    l = e - data_ptr;       // Use renamed variable
 
     fprintf(f, "section  \"%s\"", s->name);
     if (s->link)
@@ -1442,21 +1442,21 @@ static void pe_print_section(FILE *f, Section *s)
     {
         static const char *fields1[] = {"  name", "     value", "  size", "  bind", "  type", " other", " shndx", NULL};
         static const char *fields2[] = {"  offs", "  type", "  symb", NULL};
-        const char **p;
+        const char **field_names;   // Changed p to field_names
 
         if (s->sh_type == SHT_SYMTAB)
         {
-            p = fields1;
+            field_names = fields1;  // Use renamed variable
             n = 110;
         }
         else
         {
-            p = fields2;
+            field_names = fields2;  // Use renamed variable
             n = 58;
         }
 
-        for (i = 0; p[i]; ++i)
-            fprintf(f, "%s", p[i]);
+        for (i = 0; field_names[i]; ++i)  // Use renamed variable
+            fprintf(f, "%s", field_names[i]);
         fprintf(f, "  symbol");
     }
 
@@ -1472,7 +1472,7 @@ static void pe_print_section(FILE *f, Section *s)
         {
             if (n + i < l)
             {
-                fprintf(f, " %02X", p[i + n]);
+                fprintf(f, " %02X", data_ptr[i + n]);  // Use renamed variable
             }
             else
             {
@@ -1482,7 +1482,7 @@ static void pe_print_section(FILE *f, Section *s)
 
         if (s->sh_type == SHT_SYMTAB)
         {
-            Elf32_Sym *sym = (Elf32_Sym *)(p + i);
+            Elf32_Sym *sym = (Elf32_Sym *)(data_ptr + i);  // Use renamed variable
             const char *name = s->link->data + sym->st_name;
             fprintf(f, "  %04X  %08X  %04X   %02X    %02X    %02X   %04X  \"%s\"",
                     sym->st_name,
@@ -1494,7 +1494,7 @@ static void pe_print_section(FILE *f, Section *s)
         }
         else if (s->sh_type == SHT_REL)
         {
-            Elf32_Rel *rel = (Elf32_Rel *)(p + i);
+            Elf32_Rel *rel = (Elf32_Rel *)(data_ptr + i);  // Use renamed variable
             Elf32_Sym *sym = (Elf32_Sym *)s->link->data + ELF32_R_SYM(rel->r_info);
             const char *name = s->link->link->data + sym->st_name;
             fprintf(f, "  %04X   %02X   %04X  \"%s\"",
@@ -1509,7 +1509,7 @@ static void pe_print_section(FILE *f, Section *s)
             {
                 if (n + i < l)
                 {
-                    b = p[i + n];
+                    b = data_ptr[i + n];  // Use renamed variable
                     if (b < 32 || b >= 127)
                         b = '.';
                     fprintf(f, "%c", b);

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -485,8 +485,10 @@ static DWORD umax(DWORD a, DWORD b)
 static void pe_fpad(FILE *fp, DWORD new_pos, char fill)
 {
     DWORD pos = ftell(fp);
-    while (++pos <= new_pos)
+    while (pos < new_pos) {
         fputc(fill, fp);
+        pos++;
+    }
 }
 
 static DWORD align(DWORD n, DWORD a)

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -809,10 +809,10 @@ static void pe_build_imports(struct pe_info *pe)
         struct pe_import_header *hdr;
         int k, n, v;
         struct pe_import_info *p = pe->imp_info[i];
-        const char *name = pe->s1->loaded_dlls[p->dll_index - 1]->name;
+        const char *dll_name = pe->s1->loaded_dlls[p->dll_index - 1]->name;
 
         // Put the DLL name into the import header
-        v = put_elf_str(pe->thunk, name);
+        v = put_elf_str(pe->thunk, dll_name);
 
         hdr = (struct pe_import_header *)(pe->thunk->data + dll_ptr);
         hdr->first_thunk = thk_ptr + rva_base;
@@ -827,13 +827,13 @@ static void pe_build_imports(struct pe_info *pe)
                 int sym_index = p->symbols[k]->sym_index;
                 Elf32_Sym *imp_sym = (Elf32_Sym *)pe->s1->dynsymtab_section->data + sym_index;
                 Elf32_Sym *org_sym = (Elf32_Sym *)symtab_section->data + iat_index;
-                const char *name = pe->s1->dynsymtab_section->link->data + imp_sym->st_name;
+                const char *sym_name = pe->s1->dynsymtab_section->link->data + imp_sym->st_name;
 
                 org_sym->st_value = thk_ptr;
                 org_sym->st_shndx = pe->thunk->sh_num;
                 v = pe->thunk->data_offset + rva_base;
                 *(WORD *)section_ptr_add(pe->thunk, sizeof(WORD)) = imp_sym->st_other; // Hint
-                put_elf_str(pe->thunk, name);
+                put_elf_str(pe->thunk, sym_name);
             }
             else
             {

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -563,7 +563,7 @@ static int pe_write(struct pe_info *pe)
     char *stub;
     int stub_size;
     DWORD file_offset, r;
-    Section *s;
+    Section *sect;
     size_t dos_header_size = sizeof(IMAGE_DOS_HEADER);
 
     if (pe->stub)
@@ -689,14 +689,14 @@ static int pe_write(struct pe_info *pe)
         if (si->sh_size)
         {
             psh->PointerToRawData = r = file_offset;
-            for (s = si->first; s; s = s->next)
+            for (sect = si->first; sect; sect = sect->next)
             {
-                if (s->sh_type != SHT_NOBITS)
+                if (sect->sh_type != SHT_NOBITS)
                 {
-                    file_offset = align(file_offset, s->sh_addralign);
+                    file_offset = align(file_offset, sect->sh_addralign);
                     pe_fpad(op, file_offset, si->cls == sec_text ? 0x90 : 0x00);
-                    fwrite(s->data, 1, s->data_offset, op);
-                    file_offset += s->data_offset;
+                    fwrite(sect->data, 1, sect->data_offset, op);
+                    file_offset += sect->data_offset;
                 }
             }
             file_offset = pe_file_align(pe, file_offset);
@@ -982,7 +982,7 @@ static void pe_build_reloc(struct pe_info *pe)
     DWORD offset, block_ptr, addr;
     int count, i;
     Elf32_Rel *rel, *rel_end;
-    Section *s = NULL, *sr;
+    Section *sect = NULL, *sr;
 
     offset = addr = block_ptr = count = i = 0;
     rel = rel_end = NULL;
@@ -992,7 +992,7 @@ static void pe_build_reloc(struct pe_info *pe)
         if (rel < rel_end)
         {
             int type = ELF32_R_TYPE(rel->r_info);
-            addr = rel->r_offset + s->sh_addr;
+            addr = rel->r_offset + sect->sh_addr;
             rel++;
             if (type != R_386_32)
                 continue;
@@ -1015,13 +1015,13 @@ static void pe_build_reloc(struct pe_info *pe)
         }
         else
         {
-            if (s)
-                s = s->next;
-            if (!s && i < pe->sec_count)
-                s = pe->sec_info[i++].first;
-            if (s)
+            if (sect)
+                sect = sect->next;
+            if (!sect && i < pe->sec_count)
+                sect = pe->sec_info[i++].first;
+            if (sect)
             {
-                sr = s->reloc;
+                sr = sect->reloc;
                 if (sr)
                 {
                     rel = (Elf32_Rel *)sr->data;
@@ -1061,7 +1061,7 @@ static int pe_assign_addresses(struct pe_info *pe)
     struct section_info *si;
     struct section_info *merged_text;
     struct section_info *merged_data;
-    Section *s;
+    Section *sect;
 
     // pe->thunk = new_section(pe->s1, ".iedat", SHT_PROGBITS, SHF_ALLOC);
     section_order = cc_malloc(pe->s1->nb_sections * sizeof(int));
@@ -1069,10 +1069,10 @@ static int pe_assign_addresses(struct pe_info *pe)
     {
         for (i = 1; i < pe->s1->nb_sections; ++i)
         {
-            s = pe->s1->sections[i];
-            if (k == pe_section_class(s))
+            sect = pe->s1->sections[i];
+            if (k == pe_section_class(sect))
             {
-                s->sh_addr = pe->imagebase;
+                sect->sh_addr = pe->imagebase;
                 section_order[o++] = i;
             }
         }
@@ -1086,8 +1086,8 @@ static int pe_assign_addresses(struct pe_info *pe)
     for (i = 0; i < o; ++i)
     {
         k = section_order[i];
-        s = pe->s1->sections[k];
-        c = pe_section_class(s);
+        sect = pe->s1->sections[k];
+        c = pe_section_class(sect);
         si = &pe->sec_info[pe->sec_count];
 
 #ifdef PE_MERGE_DATA
@@ -1098,27 +1098,27 @@ static int pe_assign_addresses(struct pe_info *pe)
         if (c == sec_bss && merged_data != NULL)
         {
             // Append .bss to .data
-            s->sh_addr = addr = ((addr - 1) | 15) + 1;
-            addr += s->data_offset;
+            sect->sh_addr = addr = ((addr - 1) | 15) + 1;
+            addr += sect->data_offset;
             merged_data->sh_size = addr - merged_data->sh_addr;
-            merged_data->last->next = s;
-            merged_data->last = s;
+            merged_data->last->next = sect;
+            merged_data->last = sect;
             continue;
         }
 #endif
 
         if (c == sec_text)
         {
-            if (s->unused)
+            if (sect->unused)
                 continue;
             if (merged_text)
             {
-                merged_text->sh_size = align(merged_text->sh_size, s->sh_addralign);
-                s->sh_addr = merged_text->sh_addr + merged_text->sh_size;
-                merged_text->sh_size += s->data_offset;
+                merged_text->sh_size = align(merged_text->sh_size, sect->sh_addralign);
+                sect->sh_addr = merged_text->sh_addr + merged_text->sh_size;
+                merged_text->sh_size += sect->data_offset;
                 addr = merged_text->sh_addr + merged_text->sh_size;
-                merged_text->last->next = s;
-                merged_text->last = s;
+                merged_text->last->next = sect;
+                merged_text->last = sect;
                 continue;
             }
             else
@@ -1127,19 +1127,19 @@ static int pe_assign_addresses(struct pe_info *pe)
             }
         }
 
-        strcpy(si->name, c == sec_text ? ".text" : s->name);
+        strcpy(si->name, c == sec_text ? ".text" : sect->name);
         si->cls = c;
         si->ord = k;
-        si->sh_addr = s->sh_addr = addr = pe_virtual_align(addr);
-        si->sh_flags = s->sh_flags;
-        si->first = si->last = s;
+        si->sh_addr = sect->sh_addr = addr = pe_virtual_align(addr);
+        si->sh_flags = sect->sh_flags;
+        si->first = si->last = sect;
 
         if (c == sec_data && pe->thunk == NULL)
         {
-            pe->thunk = s;
+            pe->thunk = sect;
         }
 
-        if (s == pe->thunk)
+        if (sect == pe->thunk)
         {
             pe_build_imports(pe);
             pe_build_exports(pe);
@@ -1150,10 +1150,10 @@ static int pe_assign_addresses(struct pe_info *pe)
             pe_build_reloc(pe);
         }
 
-        if (s->data_offset)
+        if (sect->data_offset)
         {
-            si->sh_size = s->data_offset;
-            addr += s->data_offset;
+            si->sh_size = sect->data_offset;
+            addr += sect->data_offset;
             pe->sec_count++;
         }
     }
@@ -1267,7 +1267,7 @@ static int pe_check_symbols(struct pe_info *pe)
 
 static void pe_eliminate_unused_sections(struct pe_info *pe)
 {
-    Section *s, *sr;
+    Section *sect, *sr;
     Elf32_Sym *sym;
     Elf32_Rel *rel, *rel_end;
     int i, again, sym_index, sym_end;
@@ -1275,12 +1275,12 @@ static void pe_eliminate_unused_sections(struct pe_info *pe)
     // First mark all function text sections as unused.
     for (i = 1; i < pe->s1->nb_sections; ++i)
     {
-        s = pe->s1->sections[i];
-        if (s->sh_type == SHT_PROGBITS &&
-            (s->sh_flags & SHF_EXECINSTR) &&
-            strcmp(s->name, ".text") != 0)
+        sect = pe->s1->sections[i];
+        if (sect->sh_type == SHT_PROGBITS &&
+            (sect->sh_flags & SHF_EXECINSTR) &&
+            strcmp(sect->name, ".text") != 0)
         {
-            s->unused = 1;
+            sect->unused = 1;
         }
     }
 
@@ -1291,10 +1291,10 @@ static void pe_eliminate_unused_sections(struct pe_info *pe)
         sym = (Elf32_Sym *)symtab_section->data + sym_index;
         if (sym->st_other & 1)
         {
-            s = pe->s1->sections[sym->st_shndx];
-            s->unused = 0;
+            sect = pe->s1->sections[sym->st_shndx];
+            sect->unused = 0;
             if (verbose == 3)
-                printf("export section %s used\n", s->name);
+                printf("export section %s used\n", sect->name);
         }
         if (sym->st_shndx == SHN_UNDEF)
             sym->st_other |= 4;
@@ -1302,11 +1302,11 @@ static void pe_eliminate_unused_sections(struct pe_info *pe)
 
     // Mark section for entry point as used.
     sym = &((Elf32_Sym *)symtab_section->data)[pe->start_sym_index];
-    s = pe->s1->sections[sym->st_shndx];
-    s->unused = 0;
+    sect = pe->s1->sections[sym->st_shndx];
+    sect->unused = 0;
     sym->st_other &= ~4;
     if (verbose == 3)
-        printf("entry section %s used\n", s->name);
+        printf("entry section %s used\n", sect->name);
 
     // Keep marking sections until no more can be added.
     do
@@ -1314,11 +1314,11 @@ static void pe_eliminate_unused_sections(struct pe_info *pe)
         again = 0;
         for (i = 1; i < pe->s1->nb_sections; ++i)
         {
-            s = pe->s1->sections[i];
-            if (s->unused)
+            sect = pe->s1->sections[i];
+            if (sect->unused)
                 continue;
 
-            sr = s->reloc;
+            sr = sect->reloc;
             if (!sr)
                 continue;
 
@@ -1330,13 +1330,13 @@ static void pe_eliminate_unused_sections(struct pe_info *pe)
                 sym = &((Elf32_Sym *)symtab_section->data)[sym_index];
                 if (sym->st_shndx != SHN_UNDEF)
                 {
-                    s = pe->s1->sections[sym->st_shndx];
-                    if (s->unused)
+                    sect = pe->s1->sections[sym->st_shndx];
+                    if (sect->unused)
                     {
-                        s->unused = 0;
+                        sect->unused = 0;
                         again = 1;
                         if (verbose == 3)
-                            printf("section %s used\n", s->name);
+                            printf("section %s used\n", sect->name);
                     }
                 }
                 rel++;
@@ -1347,9 +1347,9 @@ static void pe_eliminate_unused_sections(struct pe_info *pe)
     // Find all used symbols.
     for (i = 1; i < pe->s1->nb_sections; ++i)
     {
-        s = pe->s1->sections[i];
-        sr = s->reloc;
-        if (!sr || s->unused)
+        sect = pe->s1->sections[i];
+        sr = sect->reloc;
+        if (!sr || sect->unused)
             continue;
         rel = (Elf32_Rel *)sr->data;
         rel_end = (Elf32_Rel *)(sr->data + sr->data_offset);
@@ -1384,11 +1384,11 @@ static void pe_eliminate_unused_sections(struct pe_info *pe)
         int unused_bytes = 0;
         for (i = 1; i < pe->s1->nb_sections; ++i)
         {
-            s = pe->s1->sections[i];
-            if (s->unused)
+            sect = pe->s1->sections[i];
+            if (sect->unused)
             {
-                printf("%s unused\n", s->name);
-                unused_bytes += s->data_offset;
+                printf("%s unused\n", sect->name);
+                unused_bytes += sect->data_offset;
             }
         }
         if (unused_bytes > 0)
@@ -1562,7 +1562,7 @@ static FILE *open_map_file(const char *fname, char *errbuf, size_t errsize)
 
 static void pe_print_sections(CCState *s1, const char *fname)
 {
-    Section *s;
+    Section *sect;
     FILE *f;
     int i;
     char errbuf[256];
@@ -1582,8 +1582,8 @@ static void pe_print_sections(CCState *s1, const char *fname)
 
     for (i = 1; i < s1->nb_sections; ++i)
     {
-        s = s1->sections[i];
-        pe_print_section(f, s);
+        sect = s1->sections[i];
+        pe_print_section(f, sect);
     }
     pe_print_section(f, s1->dynsymtab_section);
     fclose(f);

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -485,7 +485,8 @@ static DWORD umax(DWORD a, DWORD b)
 static void pe_fpad(FILE *fp, DWORD new_pos, char fill)
 {
     DWORD pos = ftell(fp);
-    while (pos < new_pos) {
+    while (pos < new_pos)
+    {
         fputc(fill, fp);
         pos++;
     }
@@ -508,9 +509,9 @@ static DWORD pe_virtual_align(DWORD n)
 
 static void pe_align_section(Section *s, int a)
 {
-    int i = s->data_offset & (a - 1);
-    if (i)
-        section_ptr_add(s, a - i);
+    int padding = ((a - (s->data_offset & (a - 1))) & (a - 1));
+    if (padding)
+        section_ptr_add(s, padding);
 }
 
 static void pe_set_datadir(int dir, DWORD addr, DWORD size)
@@ -1402,11 +1403,11 @@ static void pe_eliminate_unused_sections(struct pe_info *pe)
 
 static void pe_print_section(FILE *f, Section *s)
 {
-    BYTE *data_ptr, *e, b;  // Changed p to data_ptr
+    BYTE *data_ptr, *e, b; // Changed p to data_ptr
     int i, n, l, m;
-    data_ptr = s->data;     // Use renamed variable
+    data_ptr = s->data; // Use renamed variable
     e = s->data + s->data_offset;
-    l = e - data_ptr;       // Use renamed variable
+    l = e - data_ptr; // Use renamed variable
 
     fprintf(f, "section  \"%s\"", s->name);
     if (s->link)
@@ -1444,20 +1445,20 @@ static void pe_print_section(FILE *f, Section *s)
     {
         static const char *fields1[] = {"  name", "     value", "  size", "  bind", "  type", " other", " shndx", NULL};
         static const char *fields2[] = {"  offs", "  type", "  symb", NULL};
-        const char **field_names;   // Changed p to field_names
+        const char **field_names; // Changed p to field_names
 
         if (s->sh_type == SHT_SYMTAB)
         {
-            field_names = fields1;  // Use renamed variable
+            field_names = fields1; // Use renamed variable
             n = 110;
         }
         else
         {
-            field_names = fields2;  // Use renamed variable
+            field_names = fields2; // Use renamed variable
             n = 58;
         }
 
-        for (i = 0; field_names[i]; ++i)  // Use renamed variable
+        for (i = 0; field_names[i]; ++i) // Use renamed variable
             fprintf(f, "%s", field_names[i]);
         fprintf(f, "  symbol");
     }
@@ -1474,7 +1475,7 @@ static void pe_print_section(FILE *f, Section *s)
         {
             if (n + i < l)
             {
-                fprintf(f, " %02X", data_ptr[i + n]);  // Use renamed variable
+                fprintf(f, " %02X", data_ptr[i + n]); // Use renamed variable
             }
             else
             {
@@ -1484,7 +1485,7 @@ static void pe_print_section(FILE *f, Section *s)
 
         if (s->sh_type == SHT_SYMTAB)
         {
-            Elf32_Sym *sym = (Elf32_Sym *)(data_ptr + i);  // Use renamed variable
+            Elf32_Sym *sym = (Elf32_Sym *)(data_ptr + i); // Use renamed variable
             const char *name = s->link->data + sym->st_name;
             fprintf(f, "  %04X  %08X  %04X   %02X    %02X    %02X   %04X  \"%s\"",
                     sym->st_name,
@@ -1496,7 +1497,7 @@ static void pe_print_section(FILE *f, Section *s)
         }
         else if (s->sh_type == SHT_REL)
         {
-            Elf32_Rel *rel = (Elf32_Rel *)(data_ptr + i);  // Use renamed variable
+            Elf32_Rel *rel = (Elf32_Rel *)(data_ptr + i); // Use renamed variable
             Elf32_Sym *sym = (Elf32_Sym *)s->link->data + ELF32_R_SYM(rel->r_info);
             const char *name = s->link->link->data + sym->st_name;
             fprintf(f, "  %04X   %02X   %04X  \"%s\"",
@@ -1511,7 +1512,7 @@ static void pe_print_section(FILE *f, Section *s)
             {
                 if (n + i < l)
                 {
-                    b = data_ptr[i + n];  // Use renamed variable
+                    b = data_ptr[i + n]; // Use renamed variable
                     if (b < 32 || b >= 127)
                         b = '.';
                     fprintf(f, "%c", b);
@@ -1652,20 +1653,21 @@ static char *trimfront(char *p)
 
 static char *trimback(char *a, char *e)
 {
-    // Safety check to ensure e is not before a 
+    // Safety check to ensure e is not before a
     if (!e || e < a)
         e = a;
 
     // Prevent underflow by checking lower bound
     while (e > a && (unsigned char)e[-1] <= ' ')
         --e;
-    *e = 0; 
+    *e = 0;
     return a;
 }
 
 static char *get_line(char *line, int size, FILE *fp)
 {
-    if (!line || size <= 0) return NULL;
+    if (!line || size <= 0)
+        return NULL;
 
     if (fgets(line, size, fp) == NULL)
         return NULL;
@@ -1673,10 +1675,12 @@ static char *get_line(char *line, int size, FILE *fp)
     // Find end of string safely within buffer bounds
     char *p = line;
     int remaining = size;
-    while (--remaining > 0 && *p) p++;
+    while (--remaining > 0 && *p)
+        p++;
 
     // p now points to null terminator or end of buffer
-    if (remaining <= 0) p = line + size - 1;
+    if (remaining <= 0)
+        p = line + size - 1;
 
     trimback(line, p);
     return trimfront(line);

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -1629,7 +1629,7 @@ int pe_test_res_file(void *v, int size)
 
 static int read_n(int fd, void *ptr, unsigned size)
 {
-    return read(fd, ptr, siz ptr,e) == size;
+    return read(fd, ptr, size) == size;
 }
 
 int pe_load_res_file(CCState *s1, int fd)

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -1523,27 +1523,13 @@ static void pe_print_section(FILE *f, Section *s)
 
 static int is_valid_map_path(const char *path)
 {
-    const char *p;
-
     if (!path || !*path)
         return 0;
 
-    // Only allow paths without directory traversal
-    if (strchr(path, '/') || strchr(path, '\\'))
+    // Only check for path traversal attempts
+    if (strstr(path, ".."))
         return 0;
 
-    // Check for absolute paths
-    if (path[0] == '/' || path[0] == '\\')
-        return 0;
-    if (strlen(path) >= 2 && path[1] == ':')
-        return 0;
-
-    // Verify filename contains only safe chars
-    for (p = path; *p; p++)
-    {
-        if (!isalnum(*p) && *p != '.' && *p != '_' && *p != '-')
-            return 0;
-    }
     return 1;
 }
 

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -1523,13 +1523,27 @@ static void pe_print_section(FILE *f, Section *s)
 
 static int is_valid_map_path(const char *path)
 {
+    const char *p;
+
     if (!path || !*path)
         return 0;
 
-    // Only check for path traversal attempts
-    if (strstr(path, ".."))
+    // Only allow paths without directory traversal
+    if (strchr(path, '/') || strchr(path, '\\'))
         return 0;
 
+    // Check for absolute paths
+    if (path[0] == '/' || path[0] == '\\')
+        return 0;
+    if (strlen(path) >= 2 && path[1] == ':')
+        return 0;
+
+    // Verify filename contains only safe chars
+    for (p = path; *p; p++)
+    {
+        if (!isalnum(*p) && *p != '.' && *p != '_' && *p != '-')
+            return 0;
+    }
     return 1;
 }
 

--- a/sdk/src/cc/pe.c
+++ b/sdk/src/cc/pe.c
@@ -1403,11 +1403,11 @@ static void pe_eliminate_unused_sections(struct pe_info *pe)
 
 static void pe_print_section(FILE *f, Section *s)
 {
-    BYTE *data_ptr, *e, b; // Changed p to data_ptr
+    BYTE *data_ptr, *e, b; 
     int i, n, l, m;
-    data_ptr = s->data; // Use renamed variable
+    data_ptr = s->data;
     e = s->data + s->data_offset;
-    l = e - data_ptr; // Use renamed variable
+    l = (e > data_ptr) ? (int)(e - data_ptr) : 0;
 
     fprintf(f, "section  \"%s\"", s->name);
     if (s->link)


### PR DESCRIPTION
_Potential fix for [https://github.com/private-collaboration-consortium/krlean/security/code-scanning/587](https://github.com/private-collaboration-consortium/krlean/security/code-scanning/587)._

_To fix the problem, we need to validate the user input before using it to construct a file path. Specifically, we should ensure that the `def` variable does not contain any path separators or ".." sequences, which could lead to path traversal attacks._

_The best way to fix this problem without changing existing functionality is to add a validation check for the `def` variable before it is used in the `open` function. We can use the `strstr` and `strchr` functions to check for invalid sequences in the `def` variable._
