### PR TITLE
2025.01.27.0820

### DIFF
--- a/src/utils/ar/ar.c
+++ b/src/utils/ar/ar.c
@@ -213,8 +213,7 @@ void free_archive(struct archive *ar)
     while (e)
     {
         struct entry *next = e->next;
-        if (e->contents)
-            free(e->contents);
+        free(e->contents);
         free(e);
         e = next;
     }
@@ -223,8 +222,7 @@ void free_archive(struct archive *ar)
     while (s)
     {
         struct symbol *next = s->next;
-        if (s->name)
-            free(s->name);
+        free(s->name);
         free(s);
         s = next;
     }


### PR DESCRIPTION
_This pull request includes changes to the `free_archive` function in `src/utils/ar/ar.c` to simplify the code by removing unnecessary null checks before calling the `free` function._

* _[`src/utils/ar/ar.c`](diffhunk://#diff-cbe3270dd16364245b861b64f0b8f885a0c2517823c57f76a91bcbc3c93a8deeL216): Removed unnecessary null checks before calling `free` on `e->contents` and `s->name` in the `free_archive` function. [[1]](diffhunk://#diff-cbe3270dd16364245b861b64f0b8f885a0c2517823c57f76a91bcbc3c93a8deeL216) [[2]](diffhunk://#diff-cbe3270dd16364245b861b64f0b8f885a0c2517823c57f76a91bcbc3c93a8deeL226)_