### PR TITLE
2025.01.27.0943

### DIFF
--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -917,24 +917,24 @@ static expr *expr6(int critical)
                 if (!labelfunc(tokval->t_charptr, &label_seg, &label_ofs))
                 {
                     char *tmp_scope = local_scope(tokval->t_charptr);
-                    char *scope = NULL;
+                    char *tmp_scope_ptr = NULL;
                     if (tmp_scope) {
-                        scope = as_strdup(tmp_scope);
+                        tmp_scope_ptr = as_strdup(tmp_scope);
                     }
                     
                     if (critical == 2)
                     {
                         error(ERR_NONFATAL, "symbol `%s%s' undefined",
-                              scope ? scope : "", tokval->t_charptr);
-                        if (scope) as_free(scope);
+                              tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
+                        if (tmp_scope_ptr) as_free(tmp_scope_ptr);
                         return NULL;
                     }
                     else if (critical == 1)
                     {
                         error(ERR_NONFATAL,
                               "symbol `%s%s' not defined before use",
-                              scope ? scope : "", tokval->t_charptr);
-                        if (scope) as_free(scope);
+                              tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
+                        if (tmp_scope_ptr) as_free(tmp_scope_ptr);
                         return NULL;
                     }
                     else
@@ -945,7 +945,7 @@ static expr *expr6(int critical)
                         label_seg = NO_SEG;
                         label_ofs = 1;
                     }
-                    if (scope) as_free(scope);
+                    if (tmp_scope_ptr) as_free(tmp_scope_ptr);
                 }
                 if (opflags && is_extern(tokval->t_charptr))
                     *opflags |= OPFLAG_EXTERN;

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -779,7 +779,6 @@ static expr *expr6(int critical)
     int64_t label_ofs;
     int64_t tmpval;
     bool rn_warn;
-    char *scope;
 
     switch (i)
     {

--- a/sdk/src/cc/cc.c
+++ b/sdk/src/cc/cc.c
@@ -480,7 +480,7 @@ int main(int argc, char **argv)
     int i;
     CCState *s;
     int nb_objfiles, ret, oind;
-    char objfilename[1024];
+    char *alloc_outfile = NULL; // Add this to track allocated filename
     int64_t start_time = 0;
     char *alt_lib_path;
 
@@ -543,8 +543,10 @@ int main(int argc, char **argv)
             // Compute default outfile name
             char *ext;
             const char *name = strcmp(files[0], "-") == 0 ? "a" : cc_basename(files[0]);
-            pstrcpy(objfilename, sizeof(objfilename), name);
-            ext = cc_fileextension(objfilename);
+            // Allocate memory instead of using stack buffer
+            alloc_outfile = cc_malloc(1024);
+            pstrcpy(alloc_outfile, 1024, name);
+            ext = cc_fileextension(alloc_outfile);
 
             if (output_type == CC_OUTPUT_DLL)
             {
@@ -560,9 +562,9 @@ int main(int argc, char **argv)
             }
             else
             {
-                pstrcpy(objfilename, sizeof(objfilename), "a.out");
+                pstrcpy(alloc_outfile, 1024, "a.out");
             }
-            outfile = objfilename;
+            outfile = alloc_outfile;
         }
     }
 
@@ -633,6 +635,7 @@ int main(int argc, char **argv)
 
 cleanup:
     cc_delete(s);
+    if (alloc_outfile) cc_free(alloc_outfile);
 
 #ifdef MEM_DEBUG
     if (do_bench)

--- a/utils/dfs/vfs.c
+++ b/utils/dfs/vfs.c
@@ -129,12 +129,19 @@ struct fs *fslookup(char *name, char **rest)
 struct filesystem *register_filesystem(char *name, struct fsops *ops)
 {
     struct filesystem *fsys;
+    char *name_copy;
 
     fsys = (struct filesystem *)malloc(sizeof(struct filesystem));
     if (!fsys)
         return NULL;
 
-    fsys->name = name;
+    name_copy = strdup(name);
+    if (!name_copy) {
+        free(fsys);
+        return NULL;
+    }
+
+    fsys->name = name_copy;
     fsys->ops = ops;
     fsys->next = fslist;
     fslist = fsys;


### PR DESCRIPTION
_This pull request introduces several memory management improvements across multiple files in the codebase, primarily focusing on dynamically allocating and freeing memory to prevent potential memory leaks. The most important changes are grouped by theme below:_

* _[`sdk/src/as/eval.c`](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aR723-R724): Added dynamic allocation and freeing of `scope` and `full_name` in `eval_strfunc` and `expr6` functions to ensure proper memory management. [[1]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aR723-R724) [[2]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aR764-R770) [[3]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL910-R937) [[4]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aR948)_
* _[`sdk/src/cc/cc.c`](diffhunk://#diff-0ee71bd82a310c4a081fa609e21f9584526237efbd73eb3279610626a83ac20fL483-R483): Replaced stack buffer `objfilename` with dynamically allocated `alloc_outfile` in `main` function and ensured it is freed during cleanup. [[1]](diffhunk://#diff-0ee71bd82a310c4a081fa609e21f9584526237efbd73eb3279610626a83ac20fL483-R483) [[2]](diffhunk://#diff-0ee71bd82a310c4a081fa609e21f9584526237efbd73eb3279610626a83ac20fL546-R549) [[3]](diffhunk://#diff-0ee71bd82a310c4a081fa609e21f9584526237efbd73eb3279610626a83ac20fL563-R567) [[4]](diffhunk://#diff-0ee71bd82a310c4a081fa609e21f9584526237efbd73eb3279610626a83ac20fR638)_
* _[`sdk/src/cc/compiler.c`](diffhunk://#diff-a40b92745c67722d94806f62c360269c69cb4990c6fb8a3f1a04d6b3c3619991L3923-R3985): Modified `cc_add_dll` and `cc_add_library` functions to use dynamic memory allocation for `buf` and ensure it is freed appropriately._
* _[`utils/dfs/vfs.c`](diffhunk://#diff-eddbf882d0dd1f233bd77d7b4d942da688de1782324fae194573b648f2e95dc1R132-R144): Added dynamic allocation of `name_copy` in `register_filesystem` function to avoid direct assignment of input parameter `name`._