### PR TITLE
2025.01.28.0812

### DIFF
--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -908,17 +908,15 @@ static expr *expr6(int critical)
                 {
                     char *tmp_scope = local_scope(tokval->t_charptr);
                     char *tmp_scope_ptr = NULL;
-                    if (tmp_scope)
-                    {
+                    if (tmp_scope) {
                         tmp_scope_ptr = as_strdup(tmp_scope);
                     }
-
+                    
                     if (critical == 2)
                     {
                         error(ERR_NONFATAL, "symbol `%s%s' undefined",
                               tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
-                        if (tmp_scope_ptr)
-                            as_free(tmp_scope_ptr);
+                        if (tmp_scope_ptr) as_free(tmp_scope_ptr);
                         return NULL;
                     }
                     else if (critical == 1)
@@ -926,8 +924,7 @@ static expr *expr6(int critical)
                         error(ERR_NONFATAL,
                               "symbol `%s%s' not defined before use",
                               tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
-                        if (tmp_scope_ptr)
-                            as_free(tmp_scope_ptr);
+                        if (tmp_scope_ptr) as_free(tmp_scope_ptr);
                         return NULL;
                     }
                     else
@@ -938,8 +935,7 @@ static expr *expr6(int critical)
                         label_seg = NO_SEG;
                         label_ofs = 1;
                     }
-                    if (tmp_scope_ptr)
-                        as_free(tmp_scope_ptr);
+                    if (tmp_scope_ptr) as_free(tmp_scope_ptr);
                 }
                 if (opflags && is_extern(tokval->t_charptr))
                     *opflags |= OPFLAG_EXTERN;
@@ -974,7 +970,6 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
     expr *f = NULL;
     static int *safe_opflags;
     static struct tokenval safe_tokval;
-    static void *static_scpriv;
 
     hint = hints;
     if (hint)
@@ -989,8 +984,7 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
         bexpr = expr0;
 
     scan = sc;
-    static_scpriv = scprivate;
-    scpriv = static_scpriv;
+    scpriv = scprivate;
     safe_tokval = *tv;
     tokval = &safe_tokval;
     error = report_error;

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -41,6 +41,7 @@ static struct location *location; /* Pointer to current line's segment,offset */
 static int *opflags;
 
 static struct eval_hints *hint;
+static struct eval_hints *static_hints = NULL;
 
 extern int in_abs_seg;     /* ABSOLUTE segment flag */
 extern int32_t abs_seg;    /* ABSOLUTE segment */
@@ -907,15 +908,17 @@ static expr *expr6(int critical, void *scpriv)
                 {
                     char *tmp_scope = local_scope(tokval->t_charptr);
                     char *tmp_scope_ptr = NULL;
-                    if (tmp_scope) {
+                    if (tmp_scope)
+                    {
                         tmp_scope_ptr = as_strdup(tmp_scope);
                     }
-                    
+
                     if (critical == 2)
                     {
                         error(ERR_NONFATAL, "symbol `%s%s' undefined",
                               tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
-                        if (tmp_scope_ptr) as_free(tmp_scope_ptr);
+                        if (tmp_scope_ptr)
+                            as_free(tmp_scope_ptr);
                         return NULL;
                     }
                     else if (critical == 1)
@@ -923,7 +926,8 @@ static expr *expr6(int critical, void *scpriv)
                         error(ERR_NONFATAL,
                               "symbol `%s%s' not defined before use",
                               tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
-                        if (tmp_scope_ptr) as_free(tmp_scope_ptr);
+                        if (tmp_scope_ptr)
+                            as_free(tmp_scope_ptr);
                         return NULL;
                     }
                     else
@@ -934,7 +938,8 @@ static expr *expr6(int critical, void *scpriv)
                         label_seg = NO_SEG;
                         label_ofs = 1;
                     }
-                    if (tmp_scope_ptr) as_free(tmp_scope_ptr);
+                    if (tmp_scope_ptr)
+                        as_free(tmp_scope_ptr);
                 }
                 if (opflags && is_extern(tokval->t_charptr))
                     *opflags |= OPFLAG_EXTERN;
@@ -967,10 +972,10 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
 {
     expr *e;
     expr *f = NULL;
-    // Store fwref in a static variable to prevent stack escape
     static int *safe_opflags;
 
-    hint = hints;
+    static_hints = hints;
+    hint = static_hints;
     if (hint)
         hint->type = EAH_NOHINT;
 
@@ -985,7 +990,7 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
     scan = sc;
     tokval = tv;
     error = report_error;
-    safe_opflags = fwref;  // Use the safe static variable
+    safe_opflags = fwref;
     opflags = safe_opflags;
 
     if (tokval->t_type == TOKEN_INVALID)

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -34,8 +34,8 @@ static expr *tempexpr;
 static int ntempexpr;
 static int tempexpr_size;
 
-static struct tokenval *tokval; /* The current token */
-static int i;                   /* The t_type of tokval */
+// Remove the global tokval declaration
+static int i; /* The t_type of tokval */
 
 static struct location *location; /* Pointer to current line's segment,offset */
 static int *opflags;
@@ -268,26 +268,36 @@ static expr *segment_part(expr *e)
  *       | number
  */
 
-static expr *rexp0(int, void *), *rexp1(int, void *), *rexp2(int, void *), *rexp3(int, void *);
+// Update function prototypes to include tokenval parameter
+static expr *rexp0(int critical, void *scpriv, struct tokenval *tv);
+static expr *rexp1(int critical, void *scpriv, struct tokenval *tv);
+static expr *rexp2(int critical, void *scpriv, struct tokenval *tv);
+static expr *rexp3(int critical, void *scpriv, struct tokenval *tv);
+static expr *expr0(int critical, void *scpriv, struct tokenval *tv);
+static expr *expr1(int critical, void *scpriv, struct tokenval *tv);
+static expr *expr2(int critical, void *scpriv, struct tokenval *tv);
+static expr *expr3(int critical, void *scpriv, struct tokenval *tv);
+static expr *expr4(int critical, void *scpriv, struct tokenval *tv);
+static expr *expr5(int critical, void *scpriv, struct tokenval *tv);
+static expr *expr6(int critical, void *scpriv, struct tokenval *tv);
 
-static expr *expr0(int, void *), *expr1(int, void *), *expr2(int, void *), *expr3(int, void *);
+// Update the function pointer type
+static expr *(*bexpr)(int, void *, struct tokenval *);
 
-static expr *expr4(int, void *), *expr5(int, void *), *expr6(int, void *);
-
-static expr *(*bexpr)(int, void *);
-
-static expr *rexp0(int critical, void *scpriv)
+// Update all evaluation function implementations to include tv parameter
+// Here's an example for rexp0, apply similar changes to all other functions:
+static expr *rexp0(int critical, void *scpriv, struct tokenval *tv)
 {
     expr *e, *f;
 
-    e = rexp1(critical, scpriv);
+    e = rexp1(critical, scpriv, tv);
     if (!e)
         return NULL;
 
     while (i == TOKEN_DBL_OR)
     {
-        i = scan(scpriv, tokval);
-        f = rexp1(critical, scpriv);
+        i = scan(scpriv, tv);
+        f = rexp1(critical, scpriv, tv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -305,18 +315,18 @@ static expr *rexp0(int critical, void *scpriv)
     return e;
 }
 
-static expr *rexp1(int critical, void *scpriv)
+static expr *rexp1(int critical, void *scpriv, struct tokenval *tv)
 {
     expr *e, *f;
 
-    e = rexp2(critical, scpriv);
+    e = rexp2(critical, scpriv, tv);
     if (!e)
         return NULL;
 
     while (i == TOKEN_DBL_XOR)
     {
-        i = scan(scpriv, tokval);
-        f = rexp2(critical, scpriv);
+        i = scan(scpriv, tv);
+        f = rexp2(critical, scpriv, tv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -334,17 +344,17 @@ static expr *rexp1(int critical, void *scpriv)
     return e;
 }
 
-static expr *rexp2(int critical, void *scpriv)
+static expr *rexp2(int critical, void *scpriv, struct tokenval *tv)
 {
     expr *e, *f;
 
-    e = rexp3(critical, scpriv);
+    e = rexp3(critical, scpriv, tv);
     if (!e)
         return NULL;
     while (i == TOKEN_DBL_AND)
     {
-        i = scan(scpriv, tokval);
-        f = rexp3(critical, scpriv);
+        i = scan(scpriv, tv);
+        f = rexp3(critical, scpriv, tv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -361,12 +371,12 @@ static expr *rexp2(int critical, void *scpriv)
     return e;
 }
 
-static expr *rexp3(int critical, void *scpriv)
+static expr *rexp3(int critical, void *scpriv, struct tokenval *tv)
 {
     expr *e, *f;
     int64_t v;
 
-    e = expr0(critical, scpriv);
+    e = expr0(critical, scpriv, tv);
     if (!e)
         return NULL;
 
@@ -374,8 +384,8 @@ static expr *rexp3(int critical, void *scpriv)
            i == TOKEN_NE || i == TOKEN_LE || i == TOKEN_GE)
     {
         int j = i;
-        i = scan(scpriv, tokval);
-        f = expr0(critical, scpriv);
+        i = scan(scpriv, tv);
+        f = expr0(critical, scpriv, tv);
         if (!f)
             return NULL;
 
@@ -425,18 +435,18 @@ static expr *rexp3(int critical, void *scpriv)
     return e;
 }
 
-static expr *expr0(int critical, void *scpriv)
+static expr *expr0(int critical, void *scpriv, struct tokenval *tv)
 {
     expr *e, *f;
 
-    e = expr1(critical, scpriv);
+    e = expr1(critical, scpriv, tv);
     if (!e)
         return NULL;
 
     while (i == '|')
     {
-        i = scan(scpriv, tokval);
-        f = expr1(critical, scpriv);
+        i = scan(scpriv, tv);
+        f = expr1(critical, scpriv, tv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -453,18 +463,18 @@ static expr *expr0(int critical, void *scpriv)
     return e;
 }
 
-static expr *expr1(int critical, void *scpriv)
+static expr *expr1(int critical, void *scpriv, struct tokenval *tv)
 {
     expr *e, *f;
 
-    e = expr2(critical, scpriv);
+    e = expr2(critical, scpriv, tv);
     if (!e)
         return NULL;
 
     while (i == '^')
     {
-        i = scan(scpriv, tokval);
-        f = expr2(critical, scpriv);
+        i = scan(scpriv, tv);
+        f = expr2(critical, scpriv, tv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -481,18 +491,18 @@ static expr *expr1(int critical, void *scpriv)
     return e;
 }
 
-static expr *expr2(int critical, void *scpriv)
+static expr *expr2(int critical, void *scpriv, struct tokenval *tv)
 {
     expr *e, *f;
 
-    e = expr3(critical, scpriv);
+    e = expr3(critical, scpriv, tv);
     if (!e)
         return NULL;
 
     while (i == '&')
     {
-        i = scan(scpriv, tokval);
-        f = expr3(critical, scpriv);
+        i = scan(scpriv, tv);
+        f = expr3(critical, scpriv, tv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -509,19 +519,19 @@ static expr *expr2(int critical, void *scpriv)
     return e;
 }
 
-static expr *expr3(int critical, void *scpriv)
+static expr *expr3(int critical, void *scpriv, struct tokenval *tv)
 {
     expr *e, *f;
 
-    e = expr4(critical, scpriv);
+    e = expr4(critical, scpriv, tv);
     if (!e)
         return NULL;
 
     while (i == TOKEN_SHL || i == TOKEN_SHR)
     {
         int j = i;
-        i = scan(scpriv, tokval);
-        f = expr4(critical, scpriv);
+        i = scan(scpriv, tv);
+        f = expr4(critical, scpriv, tv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -549,18 +559,18 @@ static expr *expr3(int critical, void *scpriv)
     return e;
 }
 
-static expr *expr4(int critical, void *scpriv)
+static expr *expr4(int critical, void *scpriv, struct tokenval *tv)
 {
     expr *e, *f;
 
-    e = expr5(critical, scpriv);
+    e = expr5(critical, scpriv, tv);
     if (!e)
         return NULL;
     while (i == '+' || i == '-')
     {
         int j = i;
-        i = scan(scpriv, tokval);
-        f = expr5(critical, scpriv);
+        i = scan(scpriv, tv);
+        f = expr5(critical, scpriv, tv);
         if (!f)
             return NULL;
         switch (j)
@@ -576,19 +586,19 @@ static expr *expr4(int critical, void *scpriv)
     return e;
 }
 
-static expr *expr5(int critical, void *scpriv)
+static expr *expr5(int critical, void *scpriv, struct tokenval *tv)
 {
     expr *e, *f;
 
-    e = expr6(critical, scpriv);
+    e = expr6(critical, scpriv, tv);
     if (!e)
         return NULL;
     while (i == '*' || i == '/' || i == '%' ||
            i == TOKEN_SDIV || i == TOKEN_SMOD)
     {
         int j = i;
-        i = scan(scpriv, tokval);
-        f = expr6(critical, scpriv);
+        i = scan(scpriv, tv);
+        f = expr6(critical, scpriv, tv);
         if (!f)
             return NULL;
         if (j != '*' && (!(is_simple(e) || is_just_unknown(e)) ||
@@ -652,7 +662,7 @@ static expr *expr5(int critical, void *scpriv)
     return e;
 }
 
-static expr *eval_floatize(enum floatize type, void *scpriv)
+static expr *eval_floatize(enum floatize type, void *scpriv, struct tokenval *tv)
 {
     uint8_t result[16], *p; /* Up to 128 bits */
     static const struct
@@ -672,27 +682,27 @@ static expr *eval_floatize(enum floatize type, void *scpriv)
     int64_t val;
     int j;
 
-    i = scan(scpriv, tokval);
+    i = scan(scpriv, tv);
     if (i != '(')
     {
         error(ERR_NONFATAL, "expecting `('");
         return NULL;
     }
-    i = scan(scpriv, tokval);
+    i = scan(scpriv, tv);
     if (i == '-' || i == '+')
     {
         sign = (i == '-') ? -1 : 1;
-        i = scan(scpriv, tokval);
+        i = scan(scpriv, tv);
     }
     if (i != TOKEN_FLOAT)
     {
         error(ERR_NONFATAL, "expecting floating-point number");
         return NULL;
     }
-    if (!float_const(tokval->t_charptr, sign, result,
+    if (!float_const(tv->t_charptr, sign, result,
                      formats[type].bytes, error))
         return NULL;
-    i = scan(scpriv, tokval);
+    i = scan(scpriv, tv);
     if (i != ')')
     {
         error(ERR_NONFATAL, "expecting `)'");
@@ -710,11 +720,11 @@ static expr *eval_floatize(enum floatize type, void *scpriv)
     begintemp();
     addtotemp(EXPR_SIMPLE, val);
 
-    i = scan(scpriv, tokval);
+    i = scan(scpriv, tv);
     return finishtemp();
 }
 
-static expr *eval_strfunc(enum strfunc type, void *scpriv)
+static expr *eval_strfunc(enum strfunc type, void *scpriv, struct tokenval *tv)
 {
     char *string;
     size_t string_len;
@@ -722,18 +732,18 @@ static expr *eval_strfunc(enum strfunc type, void *scpriv)
     bool parens, rn_warn;
 
     parens = false;
-    i = scan(scpriv, tokval);
+    i = scan(scpriv, tv);
     if (i == '(')
     {
         parens = true;
-        i = scan(scpriv, tokval);
+        i = scan(scpriv, tv);
     }
     if (i != TOKEN_STR)
     {
         error(ERR_NONFATAL, "expecting string");
         return NULL;
     }
-    string_len = string_transform(tokval->t_charptr, tokval->t_inttwo,
+    string_len = string_transform(tv->t_charptr, tv->t_inttwo,
                                   &string, type);
     if (string_len == (size_t)-1)
     {
@@ -744,7 +754,7 @@ static expr *eval_strfunc(enum strfunc type, void *scpriv)
     val = readstrnum(string, string_len, &rn_warn);
     if (parens)
     {
-        i = scan(scpriv, tokval);
+        i = scan(scpriv, tv);
         if (i != ')')
         {
             error(ERR_NONFATAL, "expecting `)'");
@@ -758,11 +768,11 @@ static expr *eval_strfunc(enum strfunc type, void *scpriv)
     begintemp();
     addtotemp(EXPR_SIMPLE, val);
 
-    i = scan(scpriv, tokval);
+    i = scan(scpriv, tv);
     return finishtemp();
 }
 
-static expr *expr6(int critical, void *scpriv)
+static expr *expr6(int critical, void *scpriv, struct tokenval *tv)
 {
     int32_t type;
     expr *e;
@@ -774,19 +784,19 @@ static expr *expr6(int critical, void *scpriv)
     switch (i)
     {
     case '-':
-        i = scan(scpriv, tokval);
-        e = expr6(critical, scpriv);
+        i = scan(scpriv, tv);
+        e = expr6(critical, scpriv, tv);
         if (!e)
             return NULL;
         return scalar_mult(e, -1L, false);
 
     case '+':
-        i = scan(scpriv, tokval);
-        return expr6(critical, scpriv);
+        i = scan(scpriv, tv);
+        return expr6(critical, scpriv, tv);
 
     case '~':
-        i = scan(scpriv, tokval);
-        e = expr6(critical, scpriv);
+        i = scan(scpriv, tv);
+        e = expr6(critical, scpriv, tv);
         if (!e)
             return NULL;
         if (is_just_unknown(e))
@@ -800,8 +810,8 @@ static expr *expr6(int critical, void *scpriv)
         return scalarvect(~reloc_value(e));
 
     case '!':
-        i = scan(scpriv, tokval);
-        e = expr6(critical, scpriv);
+        i = scan(scpriv, tv);
+        e = expr6(critical, scpriv, tv);
         if (!e)
             return NULL;
         if (is_just_unknown(e))
@@ -815,8 +825,8 @@ static expr *expr6(int critical, void *scpriv)
         return scalarvect(!reloc_value(e));
 
     case TOKEN_SEG:
-        i = scan(scpriv, tokval);
-        e = expr6(critical, scpriv);
+        i = scan(scpriv, tv);
+        e = expr6(critical, scpriv, tv);
         if (!e)
             return NULL;
         e = segment_part(e);
@@ -830,14 +840,14 @@ static expr *expr6(int critical, void *scpriv)
         return e;
 
     case TOKEN_FLOATIZE:
-        return eval_floatize(tokval->t_integer, scpriv);
+        return eval_floatize(tv->t_integer, scpriv, tv);
 
     case TOKEN_STRFUNC:
-        return eval_strfunc(tokval->t_integer, scpriv);
+        return eval_strfunc(tv->t_integer, scpriv, tv);
 
     case '(':
-        i = scan(scpriv, tokval);
-        e = bexpr(critical, scpriv);
+        i = scan(scpriv, tv);
+        e = bexpr(critical, scpriv, tv);
         if (!e)
             return NULL;
         if (i != ')')
@@ -845,7 +855,7 @@ static expr *expr6(int critical, void *scpriv)
             error(ERR_NONFATAL, "expecting `)'");
             return NULL;
         }
-        i = scan(scpriv, tokval);
+        i = scan(scpriv, tv);
         return e;
 
     case TOKEN_NUM:
@@ -859,18 +869,18 @@ static expr *expr6(int critical, void *scpriv)
         switch (i)
         {
         case TOKEN_NUM:
-            addtotemp(EXPR_SIMPLE, tokval->t_integer);
+            addtotemp(EXPR_SIMPLE, tv->t_integer);
             break;
         case TOKEN_STR:
-            tmpval = readstrnum(tokval->t_charptr, tokval->t_inttwo, &rn_warn);
+            tmpval = readstrnum(tv->t_charptr, tv->t_inttwo, &rn_warn);
             if (rn_warn)
                 error(ERR_WARNING | ERR_PASS1, "character constant too long");
             addtotemp(EXPR_SIMPLE, tmpval);
             break;
         case TOKEN_REG:
-            addtotemp(tokval->t_integer, 1L);
+            addtotemp(tv->t_integer, 1L);
             if (hint && hint->type == EAH_NOHINT)
-                hint->base = tokval->t_integer, hint->type = EAH_MAKEBASE;
+                hint->base = tv->t_integer, hint->type = EAH_MAKEBASE;
             break;
         case TOKEN_ID:
         case TOKEN_INSN:
@@ -904,9 +914,9 @@ static expr *expr6(int critical, void *scpriv)
             }
             else
             {
-                if (!labelfunc(tokval->t_charptr, &label_seg, &label_ofs))
+                if (!labelfunc(tv->t_charptr, &label_seg, &label_ofs))
                 {
-                    char *tmp_scope = local_scope(tokval->t_charptr);
+                    char *tmp_scope = local_scope(tv->t_charptr);
                     char *tmp_scope_ptr = NULL;
                     if (tmp_scope)
                     {
@@ -916,7 +926,7 @@ static expr *expr6(int critical, void *scpriv)
                     if (critical == 2)
                     {
                         error(ERR_NONFATAL, "symbol `%s%s' undefined",
-                              tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
+                              tmp_scope_ptr ? tmp_scope_ptr : "", tv->t_charptr);
                         if (tmp_scope_ptr)
                             as_free(tmp_scope_ptr);
                         return NULL;
@@ -925,7 +935,7 @@ static expr *expr6(int critical, void *scpriv)
                     {
                         error(ERR_NONFATAL,
                               "symbol `%s%s' not defined before use",
-                              tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
+                              tmp_scope_ptr ? tmp_scope_ptr : "", tv->t_charptr);
                         if (tmp_scope_ptr)
                             as_free(tmp_scope_ptr);
                         return NULL;
@@ -941,7 +951,7 @@ static expr *expr6(int critical, void *scpriv)
                     if (tmp_scope_ptr)
                         as_free(tmp_scope_ptr);
                 }
-                if (opflags && is_extern(tokval->t_charptr))
+                if (opflags && is_extern(tv->t_charptr))
                     *opflags |= OPFLAG_EXTERN;
             }
             addtotemp(type, label_ofs);
@@ -949,7 +959,7 @@ static expr *expr6(int critical, void *scpriv)
                 addtotemp(EXPR_SEGBASE + label_seg, 1L);
             break;
         }
-        i = scan(scpriv, tokval);
+        i = scan(scpriv, tv);
         return finishtemp();
 
     default:
@@ -988,27 +998,26 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
         bexpr = expr0;
 
     scan = sc;
-    tokval = tv;
     error = report_error;
     safe_opflags = fwref;
     opflags = safe_opflags;
 
-    if (tokval->t_type == TOKEN_INVALID)
-        i = scan(scprivate, tokval);
+    if (tv->t_type == TOKEN_INVALID)
+        i = scan(scprivate, tv);
     else
-        i = tokval->t_type;
+        i = tv->t_type;
 
     while (ntempexprs) /* initialize temporary storage */
         as_free(tempexprs[--ntempexprs]);
 
-    e = bexpr(critical, scprivate);
+    e = bexpr(critical, scprivate, tv);
     if (!e)
         return NULL;
 
     if (i == TOKEN_WRT)
     {
-        i = scan(scprivate, tokval); /* eat the WRT */
-        f = expr6(critical, scprivate);
+        i = scan(scprivate, tv); /* eat the WRT */
+        f = expr6(critical, scprivate, tv);
         if (!f)
             return NULL;
     }

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -972,11 +972,15 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
 {
     expr *e;
     expr *f = NULL;
+
     static int *safe_opflags;
     static struct tokenval safe_tokval;
     static void *static_scpriv;
+    static struct eval_hints static_hints;
 
-    hint = hints;
+    static_hints = *hints;
+    hint = &static_hints;
+
     if (hint)
         hint->type = EAH_NOHINT;
 

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -972,15 +972,11 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
 {
     expr *e;
     expr *f = NULL;
-
     static int *safe_opflags;
     static struct tokenval safe_tokval;
     static void *static_scpriv;
-    static struct eval_hints static_hints;
 
-    static_hints = *hints;
-    hint = &static_hints;
-
+    hint = hints;
     if (hint)
         hint->type = EAH_NOHINT;
 

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -34,8 +34,9 @@ static expr *tempexpr;
 static int ntempexpr;
 static int tempexpr_size;
 
-static struct tokenval *tokval; /* The current token */
-static int i;                   /* The t_type of tokval */
+static struct tokenval tokval_storage;            // Actual storage instead of pointer
+static struct tokenval *tokval = &tokval_storage; // Keep pointer for compatibility
+static int i;                                     /* The t_type of tokval */
 
 static void *scpriv;
 static struct location *location; /* Pointer to current line's segment,offset */
@@ -908,15 +909,17 @@ static expr *expr6(int critical)
                 {
                     char *tmp_scope = local_scope(tokval->t_charptr);
                     char *tmp_scope_ptr = NULL;
-                    if (tmp_scope) {
+                    if (tmp_scope)
+                    {
                         tmp_scope_ptr = as_strdup(tmp_scope);
                     }
-                    
+
                     if (critical == 2)
                     {
                         error(ERR_NONFATAL, "symbol `%s%s' undefined",
                               tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
-                        if (tmp_scope_ptr) as_free(tmp_scope_ptr);
+                        if (tmp_scope_ptr)
+                            as_free(tmp_scope_ptr);
                         return NULL;
                     }
                     else if (critical == 1)
@@ -924,7 +927,8 @@ static expr *expr6(int critical)
                         error(ERR_NONFATAL,
                               "symbol `%s%s' not defined before use",
                               tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
-                        if (tmp_scope_ptr) as_free(tmp_scope_ptr);
+                        if (tmp_scope_ptr)
+                            as_free(tmp_scope_ptr);
                         return NULL;
                     }
                     else
@@ -935,7 +939,8 @@ static expr *expr6(int critical)
                         label_seg = NO_SEG;
                         label_ofs = 1;
                     }
-                    if (tmp_scope_ptr) as_free(tmp_scope_ptr);
+                    if (tmp_scope_ptr)
+                        as_free(tmp_scope_ptr);
                 }
                 if (opflags && is_extern(tokval->t_charptr))
                     *opflags |= OPFLAG_EXTERN;
@@ -968,7 +973,6 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
 {
     expr *e;
     expr *f = NULL;
-    // Store fwref in a static variable to prevent stack escape
     static int *safe_opflags;
 
     hint = hints;
@@ -985,9 +989,9 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
 
     scan = sc;
     scpriv = scprivate;
-    tokval = tv;
+    tokval_storage = *tv;
     error = report_error;
-    safe_opflags = fwref;  // Use the safe static variable
+    safe_opflags = fwref;
     opflags = safe_opflags;
 
     if (tokval->t_type == TOKEN_INVALID)

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -968,8 +968,8 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
 {
     expr *e;
     expr *f = NULL;
-    // Store fwref in a static variable to prevent stack escape
     static int *safe_opflags;
+    static struct tokenval safe_tokval;
 
     hint = hints;
     if (hint)
@@ -985,9 +985,10 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
 
     scan = sc;
     scpriv = scprivate;
-    tokval = tv;
+    safe_tokval = *tv;
+    tokval = &safe_tokval;
     error = report_error;
-    safe_opflags = fwref;  // Use the safe static variable
+    safe_opflags = fwref;
     opflags = safe_opflags;
 
     if (tokval->t_type == TOKEN_INVALID)

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -968,6 +968,8 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
 {
     expr *e;
     expr *f = NULL;
+    // Store fwref in a static variable to prevent stack escape
+    static int *safe_opflags;
 
     hint = hints;
     if (hint)
@@ -985,7 +987,8 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
     scpriv = scprivate;
     tokval = tv;
     error = report_error;
-    opflags = fwref;
+    safe_opflags = fwref;  // Use the safe static variable
+    opflags = safe_opflags;
 
     if (tokval->t_type == TOKEN_INVALID)
         i = scan(scpriv, tokval);

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -968,8 +968,8 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
 {
     expr *e;
     expr *f = NULL;
+    // Store fwref in a static variable to prevent stack escape
     static int *safe_opflags;
-    static struct tokenval safe_tokval;
 
     hint = hints;
     if (hint)
@@ -985,10 +985,9 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
 
     scan = sc;
     scpriv = scprivate;
-    safe_tokval = *tv;
-    tokval = &safe_tokval;
+    tokval = tv;
     error = report_error;
-    safe_opflags = fwref;
+    safe_opflags = fwref;  // Use the safe static variable
     opflags = safe_opflags;
 
     if (tokval->t_type == TOKEN_INVALID)

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -908,15 +908,17 @@ static expr *expr6(int critical)
                 {
                     char *tmp_scope = local_scope(tokval->t_charptr);
                     char *tmp_scope_ptr = NULL;
-                    if (tmp_scope) {
+                    if (tmp_scope)
+                    {
                         tmp_scope_ptr = as_strdup(tmp_scope);
                     }
-                    
+
                     if (critical == 2)
                     {
                         error(ERR_NONFATAL, "symbol `%s%s' undefined",
                               tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
-                        if (tmp_scope_ptr) as_free(tmp_scope_ptr);
+                        if (tmp_scope_ptr)
+                            as_free(tmp_scope_ptr);
                         return NULL;
                     }
                     else if (critical == 1)
@@ -924,7 +926,8 @@ static expr *expr6(int critical)
                         error(ERR_NONFATAL,
                               "symbol `%s%s' not defined before use",
                               tmp_scope_ptr ? tmp_scope_ptr : "", tokval->t_charptr);
-                        if (tmp_scope_ptr) as_free(tmp_scope_ptr);
+                        if (tmp_scope_ptr)
+                            as_free(tmp_scope_ptr);
                         return NULL;
                     }
                     else
@@ -935,7 +938,8 @@ static expr *expr6(int critical)
                         label_seg = NO_SEG;
                         label_ofs = 1;
                     }
-                    if (tmp_scope_ptr) as_free(tmp_scope_ptr);
+                    if (tmp_scope_ptr)
+                        as_free(tmp_scope_ptr);
                 }
                 if (opflags && is_extern(tokval->t_charptr))
                     *opflags |= OPFLAG_EXTERN;
@@ -970,6 +974,7 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
     expr *f = NULL;
     static int *safe_opflags;
     static struct tokenval safe_tokval;
+    static void *static_scpriv;
 
     hint = hints;
     if (hint)
@@ -984,7 +989,8 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
         bexpr = expr0;
 
     scan = sc;
-    scpriv = scprivate;
+    static_scpriv = scprivate;
+    scpriv = static_scpriv;
     safe_tokval = *tv;
     tokval = &safe_tokval;
     error = report_error;

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -37,7 +37,6 @@ static int tempexpr_size;
 static struct tokenval *tokval; /* The current token */
 static int i;                   /* The t_type of tokval */
 
-static void *scpriv;
 static struct location *location; /* Pointer to current line's segment,offset */
 static int *opflags;
 
@@ -268,26 +267,26 @@ static expr *segment_part(expr *e)
  *       | number
  */
 
-static expr *rexp0(int), *rexp1(int), *rexp2(int), *rexp3(int);
+static expr *rexp0(int, void *), *rexp1(int, void *), *rexp2(int, void *), *rexp3(int, void *);
 
-static expr *expr0(int), *expr1(int), *expr2(int), *expr3(int);
+static expr *expr0(int, void *), *expr1(int, void *), *expr2(int, void *), *expr3(int, void *);
 
-static expr *expr4(int), *expr5(int), *expr6(int);
+static expr *expr4(int, void *), *expr5(int, void *), *expr6(int, void *);
 
-static expr *(*bexpr)(int);
+static expr *(*bexpr)(int, void *);
 
-static expr *rexp0(int critical)
+static expr *rexp0(int critical, void *scpriv)
 {
     expr *e, *f;
 
-    e = rexp1(critical);
+    e = rexp1(critical, scpriv);
     if (!e)
         return NULL;
 
     while (i == TOKEN_DBL_OR)
     {
         i = scan(scpriv, tokval);
-        f = rexp1(critical);
+        f = rexp1(critical, scpriv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -305,18 +304,18 @@ static expr *rexp0(int critical)
     return e;
 }
 
-static expr *rexp1(int critical)
+static expr *rexp1(int critical, void *scpriv)
 {
     expr *e, *f;
 
-    e = rexp2(critical);
+    e = rexp2(critical, scpriv);
     if (!e)
         return NULL;
 
     while (i == TOKEN_DBL_XOR)
     {
         i = scan(scpriv, tokval);
-        f = rexp2(critical);
+        f = rexp2(critical, scpriv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -334,17 +333,17 @@ static expr *rexp1(int critical)
     return e;
 }
 
-static expr *rexp2(int critical)
+static expr *rexp2(int critical, void *scpriv)
 {
     expr *e, *f;
 
-    e = rexp3(critical);
+    e = rexp3(critical, scpriv);
     if (!e)
         return NULL;
     while (i == TOKEN_DBL_AND)
     {
         i = scan(scpriv, tokval);
-        f = rexp3(critical);
+        f = rexp3(critical, scpriv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -361,12 +360,12 @@ static expr *rexp2(int critical)
     return e;
 }
 
-static expr *rexp3(int critical)
+static expr *rexp3(int critical, void *scpriv)
 {
     expr *e, *f;
     int64_t v;
 
-    e = expr0(critical);
+    e = expr0(critical, scpriv);
     if (!e)
         return NULL;
 
@@ -375,7 +374,7 @@ static expr *rexp3(int critical)
     {
         int j = i;
         i = scan(scpriv, tokval);
-        f = expr0(critical);
+        f = expr0(critical, scpriv);
         if (!f)
             return NULL;
 
@@ -425,18 +424,18 @@ static expr *rexp3(int critical)
     return e;
 }
 
-static expr *expr0(int critical)
+static expr *expr0(int critical, void *scpriv)
 {
     expr *e, *f;
 
-    e = expr1(critical);
+    e = expr1(critical, scpriv);
     if (!e)
         return NULL;
 
     while (i == '|')
     {
         i = scan(scpriv, tokval);
-        f = expr1(critical);
+        f = expr1(critical, scpriv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -453,18 +452,18 @@ static expr *expr0(int critical)
     return e;
 }
 
-static expr *expr1(int critical)
+static expr *expr1(int critical, void *scpriv)
 {
     expr *e, *f;
 
-    e = expr2(critical);
+    e = expr2(critical, scpriv);
     if (!e)
         return NULL;
 
     while (i == '^')
     {
         i = scan(scpriv, tokval);
-        f = expr2(critical);
+        f = expr2(critical, scpriv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -481,18 +480,18 @@ static expr *expr1(int critical)
     return e;
 }
 
-static expr *expr2(int critical)
+static expr *expr2(int critical, void *scpriv)
 {
     expr *e, *f;
 
-    e = expr3(critical);
+    e = expr3(critical, scpriv);
     if (!e)
         return NULL;
 
     while (i == '&')
     {
         i = scan(scpriv, tokval);
-        f = expr3(critical);
+        f = expr3(critical, scpriv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -509,11 +508,11 @@ static expr *expr2(int critical)
     return e;
 }
 
-static expr *expr3(int critical)
+static expr *expr3(int critical, void *scpriv)
 {
     expr *e, *f;
 
-    e = expr4(critical);
+    e = expr4(critical, scpriv);
     if (!e)
         return NULL;
 
@@ -521,7 +520,7 @@ static expr *expr3(int critical)
     {
         int j = i;
         i = scan(scpriv, tokval);
-        f = expr4(critical);
+        f = expr4(critical, scpriv);
         if (!f)
             return NULL;
         if (!(is_simple(e) || is_just_unknown(e)) ||
@@ -549,18 +548,18 @@ static expr *expr3(int critical)
     return e;
 }
 
-static expr *expr4(int critical)
+static expr *expr4(int critical, void *scpriv)
 {
     expr *e, *f;
 
-    e = expr5(critical);
+    e = expr5(critical, scpriv);
     if (!e)
         return NULL;
     while (i == '+' || i == '-')
     {
         int j = i;
         i = scan(scpriv, tokval);
-        f = expr5(critical);
+        f = expr5(critical, scpriv);
         if (!f)
             return NULL;
         switch (j)
@@ -576,11 +575,11 @@ static expr *expr4(int critical)
     return e;
 }
 
-static expr *expr5(int critical)
+static expr *expr5(int critical, void *scpriv)
 {
     expr *e, *f;
 
-    e = expr6(critical);
+    e = expr6(critical, scpriv);
     if (!e)
         return NULL;
     while (i == '*' || i == '/' || i == '%' ||
@@ -588,7 +587,7 @@ static expr *expr5(int critical)
     {
         int j = i;
         i = scan(scpriv, tokval);
-        f = expr6(critical);
+        f = expr6(critical, scpriv);
         if (!f)
             return NULL;
         if (j != '*' && (!(is_simple(e) || is_just_unknown(e)) ||
@@ -652,7 +651,7 @@ static expr *expr5(int critical)
     return e;
 }
 
-static expr *eval_floatize(enum floatize type)
+static expr *eval_floatize(enum floatize type, void *scpriv)
 {
     uint8_t result[16], *p; /* Up to 128 bits */
     static const struct
@@ -714,7 +713,7 @@ static expr *eval_floatize(enum floatize type)
     return finishtemp();
 }
 
-static expr *eval_strfunc(enum strfunc type)
+static expr *eval_strfunc(enum strfunc type, void *scpriv)
 {
     char *string;
     size_t string_len;
@@ -762,7 +761,7 @@ static expr *eval_strfunc(enum strfunc type)
     return finishtemp();
 }
 
-static expr *expr6(int critical)
+static expr *expr6(int critical, void *scpriv)
 {
     int32_t type;
     expr *e;
@@ -775,18 +774,18 @@ static expr *expr6(int critical)
     {
     case '-':
         i = scan(scpriv, tokval);
-        e = expr6(critical);
+        e = expr6(critical, scpriv);
         if (!e)
             return NULL;
         return scalar_mult(e, -1L, false);
 
     case '+':
         i = scan(scpriv, tokval);
-        return expr6(critical);
+        return expr6(critical, scpriv);
 
     case '~':
         i = scan(scpriv, tokval);
-        e = expr6(critical);
+        e = expr6(critical, scpriv);
         if (!e)
             return NULL;
         if (is_just_unknown(e))
@@ -801,7 +800,7 @@ static expr *expr6(int critical)
 
     case '!':
         i = scan(scpriv, tokval);
-        e = expr6(critical);
+        e = expr6(critical, scpriv);
         if (!e)
             return NULL;
         if (is_just_unknown(e))
@@ -816,7 +815,7 @@ static expr *expr6(int critical)
 
     case TOKEN_SEG:
         i = scan(scpriv, tokval);
-        e = expr6(critical);
+        e = expr6(critical, scpriv);
         if (!e)
             return NULL;
         e = segment_part(e);
@@ -830,14 +829,14 @@ static expr *expr6(int critical)
         return e;
 
     case TOKEN_FLOATIZE:
-        return eval_floatize(tokval->t_integer);
+        return eval_floatize(tokval->t_integer, scpriv);
 
     case TOKEN_STRFUNC:
-        return eval_strfunc(tokval->t_integer);
+        return eval_strfunc(tokval->t_integer, scpriv);
 
     case '(':
         i = scan(scpriv, tokval);
-        e = bexpr(critical);
+        e = bexpr(critical, scpriv);
         if (!e)
             return NULL;
         if (i != ')')
@@ -984,28 +983,27 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
         bexpr = expr0;
 
     scan = sc;
-    scpriv = scprivate;
     tokval = tv;
     error = report_error;
     safe_opflags = fwref;  // Use the safe static variable
     opflags = safe_opflags;
 
     if (tokval->t_type == TOKEN_INVALID)
-        i = scan(scpriv, tokval);
+        i = scan(scprivate, tokval);
     else
         i = tokval->t_type;
 
     while (ntempexprs) /* initialize temporary storage */
         as_free(tempexprs[--ntempexprs]);
 
-    e = bexpr(critical);
+    e = bexpr(critical, scprivate);
     if (!e)
         return NULL;
 
     if (i == TOKEN_WRT)
     {
-        i = scan(scpriv, tokval); /* eat the WRT */
-        f = expr6(critical);
+        i = scan(scprivate, tokval); /* eat the WRT */
+        f = expr6(critical, scprivate);
         if (!f)
             return NULL;
     }

--- a/sdk/src/as/eval.c
+++ b/sdk/src/as/eval.c
@@ -968,8 +968,6 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
 {
     expr *e;
     expr *f = NULL;
-    // Store fwref in a static variable to prevent stack escape
-    static int *safe_opflags;
 
     hint = hints;
     if (hint)
@@ -987,8 +985,7 @@ expr *evaluate(scanner sc, void *scprivate, struct tokenval *tv,
     scpriv = scprivate;
     tokval = tv;
     error = report_error;
-    safe_opflags = fwref;  // Use the safe static variable
-    opflags = safe_opflags;
+    opflags = fwref;
 
     if (tokval->t_type == TOKEN_INVALID)
         i = scan(scpriv, tokval);

--- a/utils/dfs/vfs.c
+++ b/utils/dfs/vfs.c
@@ -202,14 +202,25 @@ int vfs_mount(char *type, char *path, vfs_devno_t devno, char *opts)
     if (!fsys)
         return -1;
 
-    // Allocate new mount point for file system
+    // Allocate and initialize new mount point for file system
     fs = (struct fs *)malloc(sizeof(struct fs));
     if (!fs)
         return -1;
+
+    // Clear the structure first
     memset(fs, 0, sizeof(struct fs));
 
+    // Copy path with bounds checking
+    if (strlen(path) >= MAXPATH + 1)
+    {
+        free(fs);
+        return -1;
+    }
+    strncpy(fs->path, path, MAXPATH);
+    fs->path[MAXPATH] = '\0';
+
+    // Initialize remaining fields
     fs->devno = devno;
-    strcpy(fs->path, path);
     fs->ops = fsys->ops;
     fs->next = mountlist;
 


### PR DESCRIPTION
_This pull request includes significant changes to the `sdk/src/as/eval.c` file to refactor function prototypes and implementations to include a `tokenval` parameter. The most important changes involve removing the global `tokval` declaration and updating the function prototypes and implementations to pass `tokenval` as a parameter._

* _Removed the global `tokval` declaration from `sdk/src/as/eval.c`._
* _Updated function prototypes to include `tokenval` parameter in `sdk/src/as/eval.c`._
* _Modified function implementations to pass `tokenval` as a parameter in `sdk/src/as/eval.c`. [[1]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL308-R329) [[2]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL337-R357) [[3]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL364-R388) [[4]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL428-R449) [[5]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL456-R477) [[6]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL484-R505) [[7]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL512-R534) [[8]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL552-R573) [[9]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL579-R601) [[10]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL655-R665) [[11]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL675-R705) [[12]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL713-R746) [[13]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL747-R757) [[14]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL761-R775) [[15]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL777-R799) [[16]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL803-R814) [[17]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL818-R829) [[18]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL833-R858) [[19]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL862-R883) [[20]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL907-R940) [[21]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL938-R962)_
* _Updated the `evaluate` function to use the new `tokenval` parameter and removed the global `tokval` usage in `sdk/src/as/eval.c`. [[1]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aR985-R988) [[2]](diffhunk://#diff-7a7eb24d24fb61de662026a4921b574ec29bb0d2c69b7a8b5cd11bd9a0e9b41aL985-R1020)_