### PR TITLE
2025.01.28.1350

### DIFF
--- a/utils/dfs/vfs.c
+++ b/utils/dfs/vfs.c
@@ -222,7 +222,8 @@ int vfs_mount(char *type, char *path, vfs_devno_t devno, char *opts)
     fs->path[MAXPATH - 1] = '\0';
 
     // Initialize the rest of the structure
-    fs->devno = devno;
+    vfs_devno_t tmp_devno = devno;
+    fs->devno = tmp_devno;
     fs->ops = fsys->ops;
 
     // Initialize filesystem on device


### PR DESCRIPTION
_This pull request includes a change to the `int vfs_mount(char *type, char *path, vfs_devno_t devno, char *opts)` function in the `utils/dfs/vfs.c` file. The change involves using a temporary variable for the `devno` parameter before assigning it to the `fs->devno` member._

* _[`utils/dfs/vfs.c`](diffhunk://#diff-eddbf882d0dd1f233bd77d7b4d942da688de1782324fae194573b648f2e95dc1L225-R226): Introduced a temporary variable `tmp_devno` for the `devno` parameter before assigning it to `fs->devno`._