### PR TITLE
2025.01.28.1417

### DIFF
--- a/utils/dfs/vfs.c
+++ b/utils/dfs/vfs.c
@@ -213,7 +213,7 @@ int vfs_mount(char *type, char *path, vfs_devno_t devno, char *opts)
     memset(fs, 0, sizeof(struct fs));
 
     // Initialize core fields first
-    fs->devno = devno;
+    memcpy(&fs->devno, &devno, sizeof(fs->devno));
     fs->ops = fsys->ops;
 
     // Copy path with bounds checking


### PR DESCRIPTION
_This pull request includes a change to the `vfs_mount` function in the `utils/dfs/vfs.c` file. The change improves the way the `devno` field is initialized._

* _Updated `vfs_mount` function to use `memcpy` for initializing the `devno` field instead of direct assignment. (`utils/dfs/vfs.c`, [utils/dfs/vfs.cL216-R216](diffhunk://#diff-eddbf882d0dd1f233bd77d7b4d942da688de1782324fae194573b648f2e95dc1L216-R216))_