### PR TITLE
2025.01.29.1008

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           cosign-release: 'v2.2.4'
       - name: 'COMPILE'
         if: github.event_name != 'pull_request'
-        run: sudo apt-get update -y && sudo apt-get install -y gcc-multilib libc6-dev-i386 kmod genisoimage squashfs-tools && make krlean cdrom
+        run: sudo apt-get update -y && sudo apt-get install -y gcc-multilib libc6-dev-i386 kmod genisoimage squashfs-tools && make krlean cdrom vmdk
       - name: 'PREPARE'
         if: github.event_name != 'pull_request'
         run: |  

--- a/sdk/src/as/assemble.c
+++ b/sdk/src/as/assemble.c
@@ -1764,11 +1764,11 @@ static void gencode(int32_t segment, int64_t offset, int bits,
                 errfunc(ERR_PANIC, "non-constant BSS size in pass two");
             else
             {
-                int64_t size = ins->oprs[0].offset;
-                if (size > 0)
+                int64_t _size = ins->oprs[0].offset;
+                if (_size > 0)
                     out(offset, segment, NULL,
-                        OUT_RESERVE, size, NO_SEG, NO_SEG);
-                offset += size;
+                        OUT_RESERVE, _size, NO_SEG, NO_SEG);
+                offset += _size;
             }
             break;
 

--- a/sdk/src/as/assemble.c
+++ b/sdk/src/as/assemble.c
@@ -446,9 +446,9 @@ int64_t assemble(int32_t segment, int64_t offset, int bits, uint32_t cp,
                 l = len;
                 while (l > 0)
                 {
-                    int32_t m;
-                    m = fread(buf, 1, l > sizeof(buf) ? sizeof(buf) : l, fp);
-                    if (!m)
+                    int32_t m2;
+                    m2 = fread(buf, 1, l > sizeof(buf) ? sizeof(buf) : l, fp);
+                    if (!m2)
                     {
                         /*
                          * This shouldn't happen unless the file
@@ -462,9 +462,9 @@ int64_t assemble(int32_t segment, int64_t offset, int bits, uint32_t cp,
                         t = 0; /* Try to exit cleanly */
                         break;
                     }
-                    out(offset, segment, buf, OUT_RAWDATA, m,
+                    out(offset, segment, buf, OUT_RAWDATA, m2,
                         NO_SEG, NO_SEG);
-                    l -= m;
+                    l -= m2;
                 }
             }
             list->downlevel(LIST_INCBIN);

--- a/sdk/src/as/out/outbin.c
+++ b/sdk/src/as/out/outbin.c
@@ -552,35 +552,35 @@ static void bin_cleanup(int debuginfo)
     list_for_each(r, relocs)
     {
         uint8_t *p, mydata[8];
-        int64_t l;
+        int64_t l2;
         int b;
 
         as_assert(r->bytes <= 8);
 
         saa_fread(r->target->contents, r->posn, mydata, r->bytes);
         p = mydata;
-        l = 0;
+        l2 = 0;
         for (b = r->bytes - 1; b >= 0; b--)
-            l = (l << 8) + mydata[b];
+            l2 = (l2 << 8) + mydata[b];
 
         s = find_section_by_index(r->secref);
         if (s)
         {
             if (r->secref == s->start_index)
-                l += s->start;
+                l2 += s->start;
             else
-                l += s->vstart;
+                l2 += s->vstart;
         }
         s = find_section_by_index(r->secrel);
         if (s)
         {
             if (r->secrel == s->start_index)
-                l -= s->start;
+                l2 -= s->start;
             else
-                l -= s->vstart;
+                l2 -= s->vstart;
         }
 
-        WRITEADDR(p, l, r->bytes);
+        WRITEADDR(p, l2, r->bytes);
         saa_fwrite(r->target->contents, r->posn, mydata, r->bytes);
     }
 

--- a/sdk/src/as/out/outobj.c
+++ b/sdk/src/as/out/outobj.c
@@ -1508,20 +1508,20 @@ static int32_t obj_segment(char *name, int pass, int *bits)
                  * already exist; then we must set the default
                  * group of this segment to be the FLAT group.
                  */
-                struct Group *grp;
-                for (grp = grphead; grp; grp = grp->next)
-                    if (!strcmp(grp->name, "FLAT"))
+                struct Group *grp2;
+                for (grp2 = grphead; grp2; grp2 = grp2->next)
+                    if (!strcmp(grp2->name, "FLAT"))
                         break;
-                if (!grp)
+                if (!grp2)
                 {
                     obj_directive(D_GROUP, "FLAT", 1);
-                    for (grp = grphead; grp; grp = grp->next)
-                        if (!strcmp(grp->name, "FLAT"))
+                    for (grp2 = grphead; grp2; grp2 = grp2->next)
+                        if (!strcmp(grp2->name, "FLAT"))
                             break;
-                    if (!grp)
+                    if (!grp2)
                         as_error(ERR_PANIC, "failure to define FLAT?!");
                 }
-                seg->grp = grp;
+                seg->grp = grp2;
             }
             else if (!as_strnicmp(p, "class=", 6))
                 seg->segclass = as_strdup(p + 6);

--- a/sdk/src/as/parser.c
+++ b/sdk/src/as/parser.c
@@ -775,10 +775,10 @@ restart_parse:
         if (mref)
         { /* it's a memory reference */
             expr *e = value;
-            int b, i, s; /* basereg, indexreg, scale */
+            int b, _i, s; /* basereg, indexreg, scale */
             int64_t o;   /* offset */
 
-            b = i = -1, o = s = 0;
+            b = _i = -1, o = s = 0;
             result->oprs[operand].hintbase = hints.base;
             result->oprs[operand].hinttype = hints.type;
 
@@ -787,13 +787,13 @@ restart_parse:
                 if (e->value == 1) /* in fact it can be basereg */
                     b = e->type;
                 else /* no, it has to be indexreg */
-                    i = e->type, s = e->value;
+                    _i = e->type, s = e->value;
                 e++;
             }
             if (e->type && e->type <= EXPR_REG_END)
             {                                  /* it's a 2nd register */
                 if (b != -1)                   /* If the first was the base, ... */
-                    i = e->type, s = e->value; /* second has to be indexreg */
+                    _i = e->type, s = e->value; /* second has to be indexreg */
 
                 else if (e->value != 1)
                 { /* If both want to be index */
@@ -908,7 +908,7 @@ restart_parse:
                 result->oprs[operand].type |= is_rel ? IP_REL : MEM_OFFS;
             }
             result->oprs[operand].basereg = b;
-            result->oprs[operand].indexreg = i;
+            result->oprs[operand].indexreg = _i;
             result->oprs[operand].scale = s;
             result->oprs[operand].offset = o;
         }

--- a/sdk/src/as/parser.c
+++ b/sdk/src/as/parser.c
@@ -1054,13 +1054,13 @@ static int is_comma_next(void)
     return (i == ',' || i == ';' || !i);
 }
 
-void cleanup_insn(insn *i)
+void cleanup_insn(insn *insn_i)
 {
     extop *e;
 
-    while ((e = i->eops))
+    while ((e = insn_i->eops))
     {
-        i->eops = e->next;
+        insn_i->eops = e->next;
         if (e->type == EOT_DB_STRING_FREE)
             as_free(e->stringval);
         as_free(e);

--- a/sdk/src/as/parser.c
+++ b/sdk/src/as/parser.c
@@ -295,11 +295,11 @@ restart_parse:
 
     if (i != TOKEN_INSN)
     {
-        int j;
+        int j2;
         enum prefixes pfx;
 
-        for (j = 0; j < MAXPREFIX; j++)
-            if ((pfx = result->prefixes[j]) != P_none)
+        for (j2 = 0; j2 < MAXPREFIX; j2++)
+            if ((pfx = result->prefixes[j2]) != P_none)
                 break;
 
         if (i == 0 && pfx != P_none)

--- a/sdk/src/as/parser.c
+++ b/sdk/src/as/parser.c
@@ -1045,13 +1045,13 @@ restart_parse:
 static int is_comma_next(void)
 {
     char *p;
-    int i;
+    int i2;
     struct tokenval tv;
 
     p = stdscan_get();
-    i = stdscan(NULL, &tv);
+    i2 = stdscan(NULL, &tv);
     stdscan_set(p);
-    return (i == ',' || i == ';' || !i);
+    return (i2 == ',' || i2 == ';' || !i2);
 }
 
 void cleanup_insn(insn *insn_i)

--- a/sdk/src/cc/asm.c
+++ b/sdk/src/cc/asm.c
@@ -706,13 +706,13 @@ void asm_parse_directive(CCState *s1)
 
     case TOK_ASM_previous:
     {
-        Section *sec;
+        Section *sec2;
         next();
         if (!last_text_section)
             error("no previous section referenced");
-        sec = cur_text_section;
+        sec2 = cur_text_section;
         use_section_ex(s1, last_text_section);
-        last_text_section = sec;
+        last_text_section = sec2;
         break;
     }
 

--- a/sdk/src/cc/asm.c
+++ b/sdk/src/cc/asm.c
@@ -627,7 +627,7 @@ void asm_parse_directive(CCState *s1)
     case TOK_ASM_asciz:
     {
         const uint8_t *p;
-        int i, size, t;
+        int i, _size, t;
 
         t = tok;
         next();
@@ -636,10 +636,10 @@ void asm_parse_directive(CCState *s1)
             if (tok != TOK_STR)
                 expect("string constant");
             p = tokc.cstr->data;
-            size = tokc.cstr->size;
-            if (t == TOK_ASM_ascii && size > 0)
-                size--;
-            for (i = 0; i < size; i++)
+            _size = tokc.cstr->_size;
+            if (t == TOK_ASM_ascii && _size > 0)
+                _size--;
+            for (i = 0; i < _size; i++)
                 g(p[i]);
             next();
             if (tok == ',')

--- a/sdk/src/cc/asm.c
+++ b/sdk/src/cc/asm.c
@@ -558,7 +558,7 @@ void asm_parse_directive(CCState *s1)
 
     case TOK_ASM_fill:
     {
-        int repeat, size, val, i, j;
+        int repeat, _size, val, i, j;
         uint8_t repeat_buf[8];
         next();
         repeat = asm_int_expr(s1);
@@ -567,19 +567,19 @@ void asm_parse_directive(CCState *s1)
             error("repeat < 0; .fill ignored");
             break;
         }
-        size = 1;
+        _size = 1;
         val = 0;
         if (tok == ',')
         {
             next();
-            size = asm_int_expr(s1);
-            if (size < 0)
+            _size = asm_int_expr(s1);
+            if (_size < 0)
             {
                 error("size < 0; .fill ignored");
                 break;
             }
-            if (size > 8)
-                size = 8;
+            if (_size > 8)
+                _size = 8;
             if (tok == ',')
             {
                 next();
@@ -597,7 +597,7 @@ void asm_parse_directive(CCState *s1)
         repeat_buf[7] = 0;
         for (i = 0; i < repeat; i++)
         {
-            for (j = 0; j < size; j++)
+            for (j = 0; j < _size; j++)
             {
                 g(repeat_buf[j]);
             }

--- a/sdk/src/cc/asm.c
+++ b/sdk/src/cc/asm.c
@@ -636,7 +636,7 @@ void asm_parse_directive(CCState *s1)
             if (tok != TOK_STR)
                 expect("string constant");
             p = tokc.cstr->data;
-            _size = tokc.cstr->_size;
+            _size = tokc.cstr->size;
             if (t == TOK_ASM_ascii && _size > 0)
                 _size--;
             for (i = 0; i < _size; i++)

--- a/sdk/src/cc/asm386.c
+++ b/sdk/src/cc/asm386.c
@@ -907,9 +907,9 @@ void asm_opcode(CCState *s1, int opcode)
         // Now decode and check each operand
         for (i = 0; i < nb_ops; i++)
         {
-            int op1, op2;
-            op1 = pa->op_type[i];
-            op2 = op1 & 0x1f;
+            int _op1, op2;
+            _op1 = pa->op_type[i];
+            op2 = _op1 & 0x1f;
             switch (op2)
             {
             case OPT_IM:
@@ -927,7 +927,7 @@ void asm_opcode(CCState *s1, int opcode)
             default:
                 v = 1 << op2;
             }
-            if (op1 & OPT_EA)
+            if (_op1 & OPT_EA)
                 v |= OP_EA;
             op_type[i] = v;
             if ((ops[i].type & v) == 0)

--- a/sdk/src/cc/elf.c
+++ b/sdk/src/cc/elf.c
@@ -1046,15 +1046,15 @@ int cc_output_file(CCState *s1, const char *filename)
                             }
                             else if (type == STT_OBJECT)
                             {
-                                unsigned long offset;
-                                offset = bss_section->data_offset;
+                                unsigned long _offset;
+                                _offset = bss_section->data_offset;
                                 // TODO: which alignment ?
-                                offset = (offset + 16 - 1) & -16;
-                                index = put_elf_sym(s1->dynsym, offset, esym->st_size, esym->st_info, 0,
+                                _offset = (_offset + 16 - 1) & -16;
+                                index = put_elf_sym(s1->dynsym, _offset, esym->st_size, esym->st_info, 0,
                                                     bss_section->sh_num, name);
-                                put_elf_reloc(s1->dynsym, bss_section, offset, R_386_COPY, index);
-                                offset += esym->st_size;
-                                bss_section->data_offset = offset;
+                                put_elf_reloc(s1->dynsym, bss_section, _offset, R_386_COPY, index);
+                                _offset += esym->st_size;
+                                bss_section->data_offset = _offset;
                             }
                         }
                         else

--- a/sdk/src/cc/elf.c
+++ b/sdk/src/cc/elf.c
@@ -1876,23 +1876,23 @@ int cc_load_object_file(CCState *s1, int fd, unsigned long file_offset)
             for (rel = (Elf32_Rel *)(s->data + offset); rel < rel_end; rel++)
             {
                 int type;
-                unsigned sym_index;
+                unsigned sym_index2;
                 // Convert symbol index
                 type = ELF32_R_TYPE(rel->r_info);
-                sym_index = ELF32_R_SYM(rel->r_info);
+                sym_index2 = ELF32_R_SYM(rel->r_info);
                 // NOTE: only one symtab assumed
-                if (sym_index >= (unsigned)nb_syms)
+                if (sym_index2 >= (unsigned)nb_syms)
                     goto invalid_reloc;
-                sym_index = old_to_new_syms[sym_index];
+                sym_index2 = old_to_new_syms[sym_index2];
                 // Ignore link_once in rel section
-                if (!sym_index && !sm->link_once)
+                if (!sym_index2 && !sm->link_once)
                 {
                 invalid_reloc:
                     error_noabort("Invalid relocation entry [%2d] '%s' @ %.8x", i, strsec + sh->sh_name,
                                   rel->r_offset);
                     goto fail;
                 }
-                rel->r_info = ELF32_R_INFO(sym_index, type);
+                rel->r_info = ELF32_R_INFO(sym_index2, type);
                 // Offset the relocation offset
                 rel->r_offset += offseti;
             }

--- a/utils/dfs/mkdfs.c
+++ b/utils/dfs/mkdfs.c
@@ -110,9 +110,9 @@ unsigned int dev_getsize(vfs_devno_t devno)
     return size;
 }
 
-void create_device(char *devname, int sizeInSectors)
+void create_device(char *devname, int devsize)
 {
-    if (bdrv_create(devtype, devname, sizeInSectors, 0) < 0)
+    if (bdrv_create(devtype, devname, devsize, 0) < 0)
         panic("unable to create device file");
 }
 

--- a/utils/dfs/mkdfs.c
+++ b/utils/dfs/mkdfs.c
@@ -110,19 +110,19 @@ unsigned int dev_getsize(vfs_devno_t devno)
     return size;
 }
 
-void create_device(char *devname, int devsize)
+void create_device(char *dev_name, int dev_size)
 {
-    if (bdrv_create(devtype, devname, devsize, 0) < 0)
+    if (bdrv_create(devtype, dev_name, dev_size, 0) < 0)
         panic("unable to create device file");
 }
 
-void clear_device(struct blockdevice *bs, int devsize)
+void clear_device(struct blockdevice *bs, int dev_size)
 {
     char sector[SECTORSIZE];
     int i;
 
     memset(sector, 0, SECTORSIZE);
-    for (i = 0; i < devsize; i++)
+    for (i = 0; i < dev_size; i++)
     {
         if (bdrv_write(bs, i, sector, 1) < 0)
             panic("error writing to device");

--- a/utils/dfs/mkdfs.c
+++ b/utils/dfs/mkdfs.c
@@ -110,9 +110,9 @@ unsigned int dev_getsize(vfs_devno_t devno)
     return size;
 }
 
-void create_device(char *devname, int devsize)
+void create_device(char *devname, int sizeInSectors)
 {
-    if (bdrv_create(devtype, devname, devsize, 0) < 0)
+    if (bdrv_create(devtype, devname, sizeInSectors, 0) < 0)
         panic("unable to create device file");
 }
 


### PR DESCRIPTION
_This pull request includes various changes to improve code readability and maintainability by renaming variables for clarity across multiple files. The most important changes involve renaming variables to avoid conflicts and improve code clarity._
* _[`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L37-R37): Modified the `COMPILE` job to include `vmdk` in the `make` command._
* _[`sdk/src/as/assemble.c`](diffhunk://#diff-6954e22ef61ed08809258ee1b35ac67b1d8338322129dc5c6ddfe7de06d3f7b5L449-R451): Renamed variables to avoid conflicts and improve readability, such as changing `m` to `m2` and `size` to `_size`. [[1]](diffhunk://#diff-6954e22ef61ed08809258ee1b35ac67b1d8338322129dc5c6ddfe7de06d3f7b5L449-R451) [[2]](diffhunk://#diff-6954e22ef61ed08809258ee1b35ac67b1d8338322129dc5c6ddfe7de06d3f7b5L465-R467) [[3]](diffhunk://#diff-6954e22ef61ed08809258ee1b35ac67b1d8338322129dc5c6ddfe7de06d3f7b5L1767-R1771)_
* _[`sdk/src/as/parser.c`](diffhunk://#diff-cdee98f29edcb86fd862f2b45459556faca321ec82a139ca88d8108e7a7ee8dbL778-R781): Renamed variables to avoid conflicts and improve readability, such as changing `i` to `_i` and `sec` to `sec2`. [[1]](diffhunk://#diff-cdee98f29edcb86fd862f2b45459556faca321ec82a139ca88d8108e7a7ee8dbL778-R781) [[2]](diffhunk://#diff-cdee98f29edcb86fd862f2b45459556faca321ec82a139ca88d8108e7a7ee8dbL790-R796) [[3]](diffhunk://#diff-cdee98f29edcb86fd862f2b45459556faca321ec82a139ca88d8108e7a7ee8dbL911-R911) [[4]](diffhunk://#diff-cdee98f29edcb86fd862f2b45459556faca321ec82a139ca88d8108e7a7ee8dbL1048-R1063)_
* _[`sdk/src/cc/asm.c`](diffhunk://#diff-50b1c521b71dc8601e6067b610a4cfd5b2e7ba3a78b0b1c283156433ec201845L561-R561): Renamed variables to avoid conflicts and improve readability, such as changing `size` to `_size` and `sec` to `sec2`. [[1]](diffhunk://#diff-50b1c521b71dc8601e6067b610a4cfd5b2e7ba3a78b0b1c283156433ec201845L561-R561) [[2]](diffhunk://#diff-50b1c521b71dc8601e6067b610a4cfd5b2e7ba3a78b0b1c283156433ec201845L570-R582) [[3]](diffhunk://#diff-50b1c521b71dc8601e6067b610a4cfd5b2e7ba3a78b0b1c283156433ec201845L600-R600) [[4]](diffhunk://#diff-50b1c521b71dc8601e6067b610a4cfd5b2e7ba3a78b0b1c283156433ec201845L630-R630)_
* _[`sdk/src/cc/asm386.c`](diffhunk://#diff-ce673500b14d5c1f7821018eea1328d751608983289c5a279ae7e112c67e283bL910-R912): Renamed variables to avoid conflicts and improve readability, such as changing `op1` to `_op1`. [[1]](diffhunk://#diff-ce673500b14d5c1f7821018eea1328d751608983289c5a279ae7e112c67e283bL910-R912) [[2]](diffhunk://#diff-ce673500b14d5c1f7821018eea1328d751608983289c5a279ae7e112c67e283bL930-R930)_
* _[`sdk/src/cc/elf.c`](diffhunk://#diff-2bcb2a61940ea36ef18bffd2538f244147690c2456d82fe8e6402d9f9e41342dL1049-R1057): Renamed variables to avoid conflicts and improve readability, such as changing `offset` to `_offset` and `sym_index` to `sym_index2`. [[1]](diffhunk://#diff-2bcb2a61940ea36ef18bffd2538f244147690c2456d82fe8e6402d9f9e41342dL1049-R1057) [[2]](diffhunk://#diff-2bcb2a61940ea36ef18bffd2538f244147690c2456d82fe8e6402d9f9e41342dL1879-R1895)_
* _[`utils/dfs/mkdfs.c`](diffhunk://#diff-2189fc57a2965f114af18e1d7cf7a45f75c127a1746b2ff1d0bd605ccba47f5bL113-R125): Renamed variables to avoid conflicts and improve readability, such as changing `devname` to `dev_name` and `devsize` to `dev_size`._